### PR TITLE
Weasyl Visual File Size Limit Increase

### DIFF
--- a/src/app/websites/website-services/weasyl/weasyl.service.ts
+++ b/src/app/websites/website-services/weasyl/weasyl.service.ts
@@ -23,7 +23,7 @@ function submissionValidate(submission: Submission, formData: SubmissionFormData
     problems.push(['Does not support file format', { website: 'Weasyl', value: submission.fileInfo.type }]);
   }
 
-  let maxMB = 10;
+  let maxMB = 50;
   const type: TypeOfSubmission = getTypeOfSubmission(submission.fileInfo);
   if (type === TypeOfSubmission.ANIMATION || type === TypeOfSubmission.AUDIO) {
     maxMB = 15;


### PR DESCRIPTION
Hello there!

Thank you for making this wonderful application. I wanted to let you know that Weasyl increased their max file limit from 10MB to 50MB on June 2nd, of this year. https://www.weasyl.com/site-updates/157

PostyBirb still thinks that the limit is 10MB, and warns you if you try to post anything larger. The exact numbers can still be verified on https://www.weasyl.com/submit.

Your numbers listed for "Literary" and "Multimedia" submissions will not be impacted by this change, however the "Visual" and "Character" categories both have 50MB limits now, so I believe that should be the default.

Thanks,
Kourii Raiko