### PR TITLE
Fix Weasyl Literary File Type Checking

### DIFF
--- a/src/app/websites/website-services/weasyl/weasyl.service.ts
+++ b/src/app/websites/website-services/weasyl/weasyl.service.ts
@@ -28,7 +28,7 @@ function submissionValidate(submission: Submission, formData: SubmissionFormData
   if (type === TypeOfSubmission.ANIMATION || type === TypeOfSubmission.AUDIO) {
     maxMB = 15;
   } else if (type === TypeOfSubmission.STORY) {
-    if (submission.fileInfo.name.includes('.md') || submission.fileInfo.name.includes('.md')) {
+    if (submission.fileInfo.name.includes('.md') || submission.fileInfo.name.includes('.txt')) {
       maxMB = 2;
     } else {
       maxMB = 10; // assume pdf


### PR DESCRIPTION
While making my [other pull request](https://github.com/mvdicarlo/postybirb/pull/48), I just noticed that the current code is checking to see if a submitted file is a ".md" file twice, when assigning a max file size of 2MB. I believe the original intention was to assign a 2MB limit to ".md" files and ".txt" files, but currently ".txt" files receive the same 10MB file size limit that ".pdf" files are given. This change should resolve that discrepancy. 

![weasyl-file-limits](https://user-images.githubusercontent.com/12603202/90529497-ca37cd80-e141-11ea-907e-0b18478954cc.png)
