### PR TITLE
chore: make i18n ci actually work

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -1,4 +1,4 @@
-name: CI
+name: i18n CI
 on:
   push:
     branches:
@@ -36,9 +36,12 @@ jobs:
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git pull
-          npx exitzero "git add 'lang/' && git commit -m 'ci: extract i18n strings'"
-          exit 0
+          
+          # pull only from main branch so it will not fetch all tags
+          git pull origin main
+          
+          git add apps/postybirb-ui/src/lang/*
+          git commit -m 'ci: extract i18n messages'
 
       - name: Push changes
         uses: ad-m/github-push-action@master


### PR DESCRIPTION
Push was not working due to wrong commit path, also the git pull was fetching all branches and all tags which was not necessary, so i fixed it.