### PR TITLE
build: add husky to dependencies explicitly

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx --no-install commitlint --edit "$1"

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 yarn

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm test

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "dep-graph": "nx dep-graph",
     "help": "nx help",
     "postinstall": "exitzero electron-builder install-app-deps",
-    "setup": "run-s setup:husky",
-    "setup:husky": "husky install",
-    "generate-migration": "drizzle-kit generate"
+    "setup": "run-s prepare",
+    "generate-migration": "drizzle-kit generate",
+    "prepare": "husky"
   },
   "dependencies": {
     "@atproto/api": "^0.15.7",
@@ -225,6 +225,7 @@
     "eslint-plugin-testing-library": "^5.0.3",
     "exitzero": "^1.0.1",
     "hbs": "^4.2.0",
+    "husky": "^9.1.7",
     "inquirer": "^12.3.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "~28.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14703,6 +14703,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"husky@npm:^9.1.7":
+  version: 9.1.7
+  resolution: "husky@npm:9.1.7"
+  bin:
+    husky: bin.js
+  checksum: 10c0/35bb110a71086c48906aa7cd3ed4913fb913823715359d65e32e0b964cb1e255593b0ae8014a5005c66a68e6fa66c38dcfa8056dbbdfb8b0187c0ffe7ee3a58f
+  languageName: node
+  linkType: hard
+
 "hyphenate-style-name@npm:^1.0.3":
   version: 1.1.0
   resolution: "hyphenate-style-name@npm:1.1.0"
@@ -20041,6 +20050,7 @@ __metadata:
     history: "npm:^5.3.0"
     html-entities: "npm:^2.6.0"
     html-to-text: "npm:^9.0.5"
+    husky: "npm:^9.1.7"
     inquirer: "npm:^12.3.0"
     jest: "npm:^29.7.0"
     jest-environment-jsdom: "npm:~28.1.1"


### PR DESCRIPTION
This PR adds husky explicitly to the development dependencies. It is not currently installed by default.

It also fixes an issue that the commit hook complains about when running, where the hashbang will no longer be respected.