### PR TITLE
fix: remove unused plugs from electron-builder.yml

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -63,9 +63,6 @@ snap:
   confinement: strict
   plugs:
     - default
-    - home
-    - network
-    - removable-media
   artifactName: "${productName}-${version}-linux-snap-${arch}.${ext}"
 
 deb:


### PR DESCRIPTION
Removed unnecessary plugs from the electron-builder configuration.