### PR TITLE
fix: improve ui styles

### DIFF
--- a/apps/postybirb-ui/src/remake/components/sections/accounts-section/website-account-card.tsx
+++ b/apps/postybirb-ui/src/remake/components/sections/accounts-section/website-account-card.tsx
@@ -124,7 +124,7 @@ function AccountRow({ account }: { account: AccountRecord }) {
       style={{
         borderRadius: 'var(--mantine-radius-sm)',
         backgroundColor: isSelected
-          ? 'var(--mantine-color-primary-light)'
+          ? 'var(--mantine-primary-color-light)'
           : undefined,
       }}
     >

--- a/apps/postybirb-ui/src/remake/components/sections/submissions-section/submission-edit-card/account-selection/account-option-row.tsx
+++ b/apps/postybirb-ui/src/remake/components/sections/submissions-section/submission-edit-card/account-selection/account-option-row.tsx
@@ -140,14 +140,13 @@ export function AccountOptionRow({
         {/* Expandable inline form section - shown when selected */}
         <Collapse
           in={expanded && isSelected}
-          ml="lg"
           key={`${account.accountId}-${websiteOption?.id ?? 'none'}`}
         >
           <Paper
             withBorder
             radius="sm"
             p="sm"
-            ml="xl"
+            ml="xs"
             mr="sm"
             mb="xs"
             className="postybirb__account_option_form"

--- a/apps/postybirb-ui/src/remake/components/sections/submissions-section/submission-edit-card/account-selection/account-selection-form.tsx
+++ b/apps/postybirb-ui/src/remake/components/sections/submissions-section/submission-edit-card/account-selection/account-selection-form.tsx
@@ -6,38 +6,38 @@
 
 import { Trans } from '@lingui/react/macro';
 import {
-    Badge,
-    Box,
-    Button,
-    Collapse,
-    Group,
-    Paper,
-    Stack,
-    Text,
-    UnstyledButton,
+  Badge,
+  Box,
+  Button,
+  Collapse,
+  Group,
+  Paper,
+  Stack,
+  Text,
+  UnstyledButton,
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
-    SubmissionRating,
-    SubmissionType,
-    type WebsiteOptionsDto,
+  SubmissionRating,
+  SubmissionType,
+  type WebsiteOptionsDto,
 } from '@postybirb/types';
 import {
-    IconChevronDown,
-    IconChevronRight,
-    IconSquare,
-    IconSquareCheck,
+  IconChevronDown,
+  IconChevronRight,
+  IconSquare,
+  IconSquareCheck,
 } from '@tabler/icons-react';
 import { useCallback, useMemo, useState } from 'react';
 import websiteOptionsApi from '../../../../../api/website-options.api';
 import { useAccounts } from '../../../../../stores/entity/account-store';
 import {
-    useFileWebsites,
-    useMessageWebsites,
+  useFileWebsites,
+  useMessageWebsites,
 } from '../../../../../stores/entity/website-store';
 import type {
-    AccountRecord,
-    WebsiteRecord,
+  AccountRecord,
+  WebsiteRecord,
 } from '../../../../../stores/records';
 import { useSubmissionEditCardContext } from '../context';
 import { AccountOptionRow } from './account-option-row';
@@ -99,7 +99,16 @@ function WebsiteAccountGroup({
         onClick={toggle}
         className="postybirb__website_group_header"
       >
-        <Group gap="xs" px="sm" py="xs" wrap="nowrap">
+        <Group
+          gap="xs"
+          px="sm"
+          py="xs"
+          wrap="nowrap"
+          style={{
+            backgroundColor:
+              selectedCount > 0 ? 'var(--mantine-primary-color-light)' : '',
+          }}
+        >
           {expanded ? (
             <IconChevronDown size={14} style={{ flexShrink: 0 }} />
           ) : (
@@ -212,7 +221,8 @@ export function AccountSelectionForm() {
 
   // Accounts that are not yet selected
   const unselectedAccounts = useMemo(
-    () => eligibleAccounts.filter((acc) => !optionsByAccount.has(acc.accountId)),
+    () =>
+      eligibleAccounts.filter((acc) => !optionsByAccount.has(acc.accountId)),
     [eligibleAccounts, optionsByAccount],
   );
 

--- a/apps/postybirb-ui/src/remake/components/sections/submissions-section/submission-edit-card/account-selection/form/validation-alerts.tsx
+++ b/apps/postybirb-ui/src/remake/components/sections/submissions-section/submission-edit-card/account-selection/form/validation-alerts.tsx
@@ -57,6 +57,8 @@ export function ValidationAlerts() {
           key={`error-${error.id}-${index}`}
           variant="light"
           color="red"
+          p="xs"
+          styles={{ title: { fontSize: 'sm' }, message: { fontSize: 'sm' } }}
           icon={<IconAlertCircle size={16} />}
         >
           <ValidationTranslation id={error.id} values={error.values} />
@@ -68,6 +70,8 @@ export function ValidationAlerts() {
           key={`warning-${warning.id}-${index}`}
           variant="light"
           color="yellow"
+          p="xs"
+          styles={{ title: { fontSize: 'sm' }, message: { fontSize: 'sm' } }}
           icon={<IconAlertTriangle size={16} />}
         >
           <ValidationTranslation id={warning.id} values={warning.values} />

--- a/apps/postybirb-ui/src/remake/components/sections/submissions-section/submissions-section.css
+++ b/apps/postybirb-ui/src/remake/components/sections/submissions-section/submissions-section.css
@@ -68,9 +68,9 @@
 }
 
 .postybirb__submission__card--selected {
-  background-color: var(--mantine-color-primary-light);
-  border-color: var(--mantine-color-primary-filled);
-  border-left: 3px solid var(--mantine-color-primary-filled) !important;
+  background-color: var(--mantine-primary-color-light);
+  border-color: var(--mantine-primary-color-filled);
+  border-left: 3px solid var(--mantine-primary-color-filled) !important;
 }
 
 .postybirb__submission__card--scheduled {
@@ -78,7 +78,11 @@
 }
 
 .postybirb__submission__card--scheduled.postybirb__submission__card--selected {
-  background-color: color-mix(in srgb, var(--mantine-color-blue-light) 50%, var(--mantine-color-primary-light) 50%);
+  background-color: color-mix(
+    in srgb,
+    var(--mantine-color-blue-light) 50%,
+    var(--mantine-primary-color-light) 50%
+  );
 }
 
 .postybirb__submission__card--has-errors {
@@ -87,7 +91,11 @@
 }
 
 .postybirb__submission__card--has-errors.postybirb__submission__card--selected {
-  background-color: color-mix(in srgb, var(--mantine-color-red-light) 60%, var(--mantine-color-primary-light) 40%);
+  background-color: color-mix(
+    in srgb,
+    var(--mantine-color-red-light) 60%,
+    var(--mantine-primary-color-light) 40%
+  );
   border-left: 3px solid var(--mantine-color-red-6) !important;
 }
 

--- a/apps/postybirb-ui/src/remake/index.tsx
+++ b/apps/postybirb-ui/src/remake/index.tsx
@@ -6,6 +6,8 @@
 import '@mantine/core/styles.css';
 import '@mantine/dates/styles.css';
 import '@mantine/notifications/styles.css';
+import './styles/layout.css';
+import './theme/theme-styles.css';
 
 import { MantineProvider, useMantineColorScheme } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
@@ -17,10 +19,8 @@ import { Layout } from './components/layout/layout';
 import { I18nProvider } from './providers/i18n-provider';
 import { loadAllStores } from './stores';
 import { useColorScheme, usePrimaryColor } from './stores/ui/appearance-store';
-import './styles/layout.css';
 import { cssVariableResolver } from './theme/css-variable-resolver';
 import { createAppTheme } from './theme/theme';
-import './theme/theme-styles.css';
 
 const queryClient = new QueryClient({
   defaultOptions: {


### PR DESCRIPTION
1) Reduced spacing on the left side of the website options
2) Reduced spacing/font size of the warnings/errors to make them more compact
3) Fixed primary color not being applied correctly because of the wrong css variable name
4) Website groups are now colored if at least one account is selected, as was requested in discord

Before/After
<img width="1280" height="798" alt="изображение" src="https://github.com/user-attachments/assets/51d7113a-71f3-4877-bf1b-6bb643a213c5" />
<img width="1280" height="805" alt="изображение" src="https://github.com/user-attachments/assets/561c03b4-07c3-49ec-88db-9a4bbc8c412d" />
