### PR TITLE
Update external link for phone number formatting

### DIFF
--- a/apps/postybirb-ui/src/remake/components/website-login-views/telegram/telegram-login-view.tsx
+++ b/apps/postybirb-ui/src/remake/components/website-login-views/telegram/telegram-login-view.tsx
@@ -87,7 +87,7 @@ export default function TelegramLoginView(
           defaultValue={phoneNumber}
           required
           description={
-            <ExternalLink href="https://developers.omnisend.com/guides/e164-phone-number-formatting">
+            <ExternalLink href="https://www.twilio.com/docs/glossary/what-e164">
               <Trans context="telegram.phone-number-help">
                 Phone number must be in international format
               </Trans>


### PR DESCRIPTION
I noticed that the link is dead for the Telegram phone number help, so I replaced it with another one :) 