### PR TITLE
fix(ui): disable File System Access API in dropzones to prevent stuck picker in Electron

### DIFF
--- a/apps/postybirb-ui/src/remake/components/sections/submissions-section/file-submission-modal/file-dropzone.tsx
+++ b/apps/postybirb-ui/src/remake/components/sections/submissions-section/file-submission-modal/file-dropzone.tsx
@@ -141,6 +141,7 @@ export function FileDropzone({ onDrop, isUploading, type }: FileDropzoneProps) {
       <Dropzone
         onDrop={onDrop}
         accept={acceptedMimeTypes}
+        useFsAccessApi={false}
         loading={isUploading}
         disabled={isUploading}
         styles={{

--- a/apps/postybirb-ui/src/remake/components/sections/submissions-section/submission-edit-card/file-management/file-uploader.tsx
+++ b/apps/postybirb-ui/src/remake/components/sections/submissions-section/submission-edit-card/file-management/file-uploader.tsx
@@ -5,11 +5,11 @@
 import { Trans } from '@lingui/react/macro';
 import { Box, Group, Text, rem } from '@mantine/core';
 import {
-  Dropzone,
-  FileWithPath,
-  IMAGE_MIME_TYPE,
-  MS_WORD_MIME_TYPE,
-  PDF_MIME_TYPE,
+    Dropzone,
+    FileWithPath,
+    IMAGE_MIME_TYPE,
+    MS_WORD_MIME_TYPE,
+    PDF_MIME_TYPE,
 } from '@mantine/dropzone';
 import { FileType } from '@postybirb/types';
 import { getFileType } from '@postybirb/utils/file-type';
@@ -17,9 +17,9 @@ import { IconPhoto, IconUpload, IconX } from '@tabler/icons-react';
 import { useState } from 'react';
 import fileSubmissionApi from '../../../../../api/file-submission.api';
 import {
-  showErrorNotification,
-  showUploadErrorNotification,
-  showWarningNotification,
+    showErrorNotification,
+    showUploadErrorNotification,
+    showWarningNotification,
 } from '../../../../../utils/notifications';
 import { useSubmissionEditCardContext } from '../context';
 
@@ -118,6 +118,7 @@ export function FileUploader() {
         ...AUDIO_MIME_TYPES,
         ...TEXT_MIME_TYPES,
       ]}
+      useFsAccessApi={false}
       loading={uploading}
       multiple
     >

--- a/apps/postybirb-ui/src/remake/components/sections/submissions-section/submission-section-header.tsx
+++ b/apps/postybirb-ui/src/remake/components/sections/submissions-section/submission-section-header.tsx
@@ -313,6 +313,7 @@ export function SubmissionSectionHeader({
               ...PDF_MIME_TYPE,
               ...MS_WORD_MIME_TYPE,
             ]}
+            useFsAccessApi={false}
             py={6}
             style={{ cursor: 'pointer' }}
           >


### PR DESCRIPTION
Mantine Dropzone uses showOpenFilePicker by default, which hangs when selecting files from restricted paths (e.g. %TEMP%) in Electron, leaving the picker permanently active and blocking future opens with NotAllowedError.

Set useFsAccessApi={false} on all Dropzone instances to force the reliable <input type=file> fallback.