### PR TITLE
fix: cookies parse error

### DIFF
--- a/apps/postybirb/src/app/events/electron.events.ts
+++ b/apps/postybirb/src/app/events/electron.events.ts
@@ -25,9 +25,7 @@ ipcMain.handle('get-cookies-for-account', async (event, accountId: string) => {
   const cookies = await session
     .fromPartition(`persist:${accountId}`)
     .cookies.get({});
-  if (cookies.length === 0) {
-    return '';
-  }
+
   return Buffer.from(JSON.stringify(cookies)).toString('base64');
 });
 


### PR DESCRIPTION
2026.04.05 09:07:31.766 [INFO] [RemoteService] Updating cookies from remote client { accountId: 'e35ca91b-495b-4213-8ec4-3102701bff5a' }
[Nest] 21  - 04/05/2026, 9:07:31 AM   ERROR [ExceptionsHandler] Unexpected end of JSON input SyntaxError: Unexpected end of JSON input
     at JSON.parse (<anonymous>)
     at RemoteService.setCookies (/app/resources/app.asar/dist/apps/postybirb/main.js:13494:30)
     at RemoteController.setCookies (/app/resources/app.asar/dist/apps/postybirb/main.js:27149:35)
     at /app/resources/app.asar/node_modules/@nestjs/core/router/router-execution-context.js:38:29
     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
