### PR TITLE
Standartize calendar and date pickers

### DIFF
--- a/apps/client-server/src/app/settings/settings.service.spec.ts
+++ b/apps/client-server/src/app/settings/settings.service.spec.ts
@@ -45,7 +45,6 @@ describe('SettingsService', () => {
         showWikiInHelpOnHover: false,
       },
       hiddenWebsites: ['test'],
-      language: 'en',
       allowAd: true,
       queuePaused: false,
     };

--- a/apps/postybirb-ui/src/components/dialogs/settings-dialog/sections/appearance-settings-section.tsx
+++ b/apps/postybirb-ui/src/components/dialogs/settings-dialog/sections/appearance-settings-section.tsx
@@ -17,7 +17,7 @@ import {
 } from '@mantine/core';
 import { IconMoon, IconSun, IconSunMoon } from '@tabler/icons-react';
 import { useMemo } from 'react';
-import { useLocale } from '../../../../hooks/use-locale.js';
+import { useLocale } from '../../../../hooks/use-locale';
 import {
   type ColorScheme,
   MANTINE_COLORS,

--- a/apps/postybirb-ui/src/components/dialogs/settings-dialog/sections/appearance-settings-section.tsx
+++ b/apps/postybirb-ui/src/components/dialogs/settings-dialog/sections/appearance-settings-section.tsx
@@ -1,13 +1,14 @@
 /**
- * Appearance Settings Section - Theme and color customization.
+ * Appearance Settings Section - Theme, color, and regional customization.
  */
 
-import { Trans } from '@lingui/react/macro';
+import { Trans, useLingui } from '@lingui/react/macro';
 import {
   Box,
   ColorSwatch,
   Group,
   SegmentedControl,
+  Select,
   SimpleGrid,
   Stack,
   Text,
@@ -15,12 +16,15 @@ import {
   useMantineTheme,
 } from '@mantine/core';
 import { IconMoon, IconSun, IconSunMoon } from '@tabler/icons-react';
+import { useMemo } from 'react';
+import { useLocale } from '../../../../hooks/use-locale.js';
 import {
   type ColorScheme,
   MANTINE_COLORS,
   type MantinePrimaryColor,
   useAppearanceActions,
 } from '../../../../stores/ui/appearance-store';
+import { useLanguageActions } from '../../../../stores/ui/locale-store';
 
 /**
  * Color scheme options for the segmented control.
@@ -72,6 +76,60 @@ export function AppearanceSettingsSection() {
   const theme = useMantineTheme();
   const { colorScheme, primaryColor, setColorScheme, setPrimaryColor } =
     useAppearanceActions();
+  const { hourCycle, setHourCycle, startOfWeek, setStartOfWeek } =
+    useLanguageActions();
+  const locale = useLocale();
+
+  const { t } = useLingui();
+
+  const weekdayOptions = useMemo(() => {
+    // Build localized weekday names (Sunday to Saturday)
+    const baseDate = new Date(2024, 0, 7); // known Sunday
+    const weekdayNames = Array.from({ length: 7 }, (_, i) => {
+      const date = new Date(baseDate);
+      date.setDate(baseDate.getDate() + i);
+
+      const name = new Intl.DateTimeFormat(locale.locale, {
+        weekday: 'long',
+      }).format(date);
+      return capitalize(name);
+    });
+
+    const defaultStartOfWeek = weekdayNames[locale.defaultStartOfWeek];
+    const options = [
+      { value: 'locale', label: t`Locale default (${defaultStartOfWeek})` },
+    ];
+
+    // Add numeric options (0 = Sunday ... 6 = Saturday)
+    for (const [i, label] of weekdayNames.entries()) {
+      options.push({ value: i.toString(), label });
+    }
+
+    return options;
+  }, [locale.defaultStartOfWeek, locale.locale, t]);
+
+  const defaultLocaleHours = locale.defaultHourCycle.slice(1);
+  const hourCycleOptions = useMemo(
+    () => [
+      {
+        value: 'locale',
+        label: <Trans>Locale default ({defaultLocaleHours})</Trans>,
+      },
+      { value: 'h12', label: '12h' },
+      { value: 'h24', label: '24h' },
+    ],
+    [defaultLocaleHours],
+  );
+
+  // Handle start of week change: if 'locale' is selected, store the numeric default
+  const handleStartOfWeekChange = (value: string | null) => {
+    if (value === null) return;
+    if (value === 'locale') {
+      setStartOfWeek('locale');
+    } else {
+      setStartOfWeek(parseInt(value, 10));
+    }
+  };
 
   return (
     <Stack gap="xl">
@@ -87,6 +145,9 @@ export function AppearanceSettingsSection() {
 
       {/* Primary Color Selection */}
       <Box>
+        <Text size="sm" fw={500} mb="xs">
+          <Trans>Primary color</Trans>
+        </Text>
         <SimpleGrid cols={6} spacing="sm">
           {MANTINE_COLORS.map((color) => {
             const isSelected = primaryColor === color;
@@ -94,11 +155,7 @@ export function AppearanceSettingsSection() {
             const colorValue = theme.colors[color][6];
 
             return (
-              <Tooltip
-                key={color}
-                label={capitalize(color)}
-                withArrow
-              >
+              <Tooltip key={color} label={capitalize(color)} withArrow>
                 <Box
                   onClick={() => setPrimaryColor(color as MantinePrimaryColor)}
                   style={{
@@ -118,6 +175,36 @@ export function AppearanceSettingsSection() {
             );
           })}
         </SimpleGrid>
+      </Box>
+
+      {/* Hour Cycle Selection */}
+      <Box>
+        <Text size="sm" fw={500} mb="xs">
+          <Trans>Hour cycle</Trans>
+        </Text>
+        <SegmentedControl
+          value={hourCycle}
+          onChange={(value) => setHourCycle(value as 'locale' | 'h12' | 'h24')}
+          data={hourCycleOptions}
+          fullWidth
+        />
+      </Box>
+
+      {/* Start of Week Selection */}
+      <Box>
+        <Text size="sm" fw={500} mb="xs">
+          <Trans>Start of week</Trans>
+        </Text>
+        <Select
+          value={
+            startOfWeek === locale.defaultStartOfWeek
+              ? 'locale'
+              : startOfWeek.toString()
+          }
+          onChange={handleStartOfWeekChange}
+          data={weekdayOptions}
+          allowDeselect={false}
+        />
       </Box>
     </Stack>
   );

--- a/apps/postybirb-ui/src/components/drawers/schedule-drawer/schedule-calendar.tsx
+++ b/apps/postybirb-ui/src/components/drawers/schedule-drawer/schedule-calendar.tsx
@@ -3,8 +3,14 @@
  * Supports drag-drop from external elements, event moving, and click-to-manage.
  */
 
-import { EventClickArg, EventDropArg } from '@fullcalendar/core';
-import { EventImpl } from '@fullcalendar/core/internal';
+import {
+  createPlugin,
+  EventClickArg,
+  EventDropArg,
+  EventInput,
+  LocaleInput,
+} from '@fullcalendar/core';
+import { EventImpl, VerboseFormattingArg } from '@fullcalendar/core/internal';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin, { DropArg } from '@fullcalendar/interaction';
 import FullCalendar from '@fullcalendar/react';
@@ -29,7 +35,7 @@ import {
   IconMessage,
 } from '@tabler/icons-react';
 import Cron from 'croner';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import submissionApi from '../../../api/submission.api';
 import { useLocale } from '../../../hooks';
@@ -40,12 +46,33 @@ import {
   showUpdateErrorNotification,
 } from '../../../utils/notifications';
 
+const dayjsPlugin = createPlugin({
+  name: 'dayjs',
+  cmdFormatter(cmdStr: string, arg: VerboseFormattingArg): string {
+    const locale = arg.localeCodes[0];
+    if (arg.end) {
+      const start = dayjs(...arg.start.array).locale(locale);
+      const end = dayjs(...arg.end.array).locale(locale);
+      return `${start.format(cmdStr)} – ${end.format(cmdStr)}`;
+    }
+    return dayjs(...arg.date.array)
+      .locale(locale)
+      .format(cmdStr);
+  },
+});
+
 /**
  * Calendar component for schedule drawer.
  * Shows all scheduled submissions (both FILE and MESSAGE types).
  */
 export function ScheduleCalendar() {
-  const { calendarLocale, formatRelativeTime, formatDateTime } = useLocale();
+  const {
+    calendarLocale,
+    formatRelativeTime,
+    formatDateTime,
+    startOfWeek,
+    hourCycle,
+  } = useLocale();
   const scheduledSubmissions = useSubmissionsWithSchedule();
   const [selectedEvent, setSelectedEvent] = useState<EventImpl | null>(null);
   const [modalOpened, setModalOpened] = useState(false);
@@ -53,10 +80,10 @@ export function ScheduleCalendar() {
   const calendarRef = useRef<any>(null);
 
   // Format events for FullCalendar
-  const events = useMemo(
+  const events: EventInput[] = useMemo(
     () =>
       scheduledSubmissions.flatMap((submission) => {
-        const result = [];
+        const result: EventInput[] = [];
         const { title } = submission;
         const isMessageType = submission.type === SubmissionType.MESSAGE;
 
@@ -66,7 +93,7 @@ export function ScheduleCalendar() {
             result.push({
               id: submission.id,
               title,
-              start: moment(submission.schedule.scheduledFor).toISOString(),
+              start: dayjs(submission.schedule.scheduledFor).toISOString(),
               backgroundColor: isMessageType ? '#40c057' : '#339af0',
               borderColor: isMessageType ? '#40c057' : '#339af0',
               textColor: '#ffffff',
@@ -85,7 +112,7 @@ export function ScheduleCalendar() {
             result.push({
               id: `${submission.id}-recurring-${index}`,
               title,
-              start: moment(nextRun).toISOString(),
+              start: dayjs(nextRun).toISOString(),
               backgroundColor: isMessageType ? '#69db7c' : '#74c0fc',
               borderColor: isMessageType ? '#69db7c' : '#74c0fc',
               textColor: '#ffffff',
@@ -101,7 +128,8 @@ export function ScheduleCalendar() {
           result.push({
             id: submission.id,
             title,
-            start: moment(submission.schedule.scheduledFor).toISOString(),
+            start: dayjs(submission.schedule.scheduledFor).toISOString(),
+            startEditable: true,
             backgroundColor: submission.isScheduled
               ? isMessageType
                 ? '#40c057'
@@ -111,7 +139,7 @@ export function ScheduleCalendar() {
               ? isMessageType
                 ? '#40c057'
                 : '#339af0'
-              : '#909296',
+              : '#4D4D4E',
             textColor: '#ffffff',
             extendedProps: {
               type: submission.isScheduled ? 'scheduled' : 'unscheduled',
@@ -179,7 +207,7 @@ export function ScheduleCalendar() {
       .then(() => {
         showInfoNotification(
           selectedEvent.title,
-          <Trans>Submission unscheduled</Trans>
+          <Trans>Submission unscheduled</Trans>,
         );
       })
       .catch((error) => {
@@ -211,7 +239,12 @@ export function ScheduleCalendar() {
     <div style={{ overflow: 'auto', position: 'relative', height: '100%' }}>
       <FullCalendar
         ref={calendarRef}
-        plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
+        plugins={[
+          dayGridPlugin,
+          timeGridPlugin,
+          interactionPlugin,
+          dayjsPlugin,
+        ]}
         headerToolbar={{
           // eslint-disable-next-line lingui/no-unlocalized-strings
           left: 'prev,next today',
@@ -226,7 +259,10 @@ export function ScheduleCalendar() {
         allDaySlot={false}
         weekends
         events={events}
-        locale={calendarLocale}
+        locale={calendarLocale as LocaleInput}
+        firstDay={startOfWeek}
+        // eslint-disable-next-line lingui/no-unlocalized-strings
+        eventTimeFormat={hourCycle === 'h12' ? 'hh:mm A' : 'HH:mm'}
         eventDrop={handleEventDrop}
         height="100%"
         themeSystem="standard"
@@ -253,9 +289,7 @@ export function ScheduleCalendar() {
               <IconClock size={14} />
             </ThemeIcon>
             <Text size="sm" c="dimmed">
-              {selectedEvent?.start
-                ? formatDateTime(selectedEvent.start)
-                : ''}
+              {selectedEvent?.start ? formatDateTime(selectedEvent.start) : ''}
             </Text>
           </Group>
           {selectedEvent?.start && (

--- a/apps/postybirb-ui/src/components/drawers/schedule-drawer/schedule-calendar.tsx
+++ b/apps/postybirb-ui/src/components/drawers/schedule-drawer/schedule-calendar.tsx
@@ -26,6 +26,8 @@ import {
   Text,
   ThemeIcon,
 } from '@mantine/core';
+import { TimePicker } from '@mantine/dates';
+import { useDebouncedCallback } from '@mantine/hooks';
 import { ScheduleType, SubmissionType } from '@postybirb/types';
 import {
   IconCalendarOff,
@@ -51,11 +53,16 @@ const dayjsPlugin = createPlugin({
   cmdFormatter(cmdStr: string, arg: VerboseFormattingArg): string {
     const locale = arg.localeCodes[0];
     if (arg.end) {
-      const start = dayjs(...arg.start.array).locale(locale);
-      const end = dayjs(...arg.end.array).locale(locale);
+      const start = dayjs(new Date(...(arg.start.array as [number]))).locale(
+        locale,
+      );
+      const end = dayjs(new Date(...(arg.end.array as [number]))).locale(
+        locale,
+      );
       return `${start.format(cmdStr)} – ${end.format(cmdStr)}`;
     }
-    return dayjs(...arg.date.array)
+
+    return dayjs(new Date(...(arg.date.array as [number])))
       .locale(locale)
       .format(cmdStr);
   },
@@ -69,7 +76,7 @@ export function ScheduleCalendar() {
   const {
     calendarLocale,
     formatRelativeTime,
-    formatDateTime,
+    formatDate,
     startOfWeek,
     hourCycle,
   } = useLocale();
@@ -129,7 +136,6 @@ export function ScheduleCalendar() {
             id: submission.id,
             title,
             start: dayjs(submission.schedule.scheduledFor).toISOString(),
-            startEditable: true,
             backgroundColor: submission.isScheduled
               ? isMessageType
                 ? '#40c057'
@@ -139,7 +145,7 @@ export function ScheduleCalendar() {
               ? isMessageType
                 ? '#40c057'
                 : '#339af0'
-              : '#4D4D4E',
+              : '#909296',
             textColor: '#ffffff',
             extendedProps: {
               type: submission.isScheduled ? 'scheduled' : 'unscheduled',
@@ -235,6 +241,33 @@ export function ScheduleCalendar() {
     setModalOpened(false);
   };
 
+  const handleScheduleTimeChange = useDebouncedCallback(
+    (time: string) => {
+      if (!time || !selectedEvent?.start) return;
+      const [hours, minutes] = time.split(':').map((n) => parseInt(n, 10));
+
+      if (typeof hours !== 'number' || typeof minutes !== 'number') return;
+
+      const scheduledFor = new Date(selectedEvent.start);
+
+      scheduledFor.setHours(hours);
+      scheduledFor.setMinutes(minutes);
+
+      submissionApi
+        .update(selectedEvent.id, { scheduledFor: scheduledFor.toISOString() })
+        .then(() => {
+          showScheduleUpdatedNotification(selectedEvent.title);
+        })
+        .catch((error) => {
+          showUpdateErrorNotification(error.message);
+        });
+    },
+    { delay: 500, flushOnUnmount: false },
+  );
+
+  // eslint-disable-next-line lingui/no-unlocalized-strings
+  const timeFormat = hourCycle === 'h12' ? 'hh:mm A' : 'HH:mm';
+
   return (
     <div style={{ overflow: 'auto', position: 'relative', height: '100%' }}>
       <FullCalendar
@@ -257,17 +290,20 @@ export function ScheduleCalendar() {
         selectMirror
         dayMaxEvents
         allDaySlot={false}
+        // fixes issue with offset on drag
+        fixedMirrorParent={document.body}
         weekends
         events={events}
         locale={calendarLocale as LocaleInput}
         firstDay={startOfWeek}
-        // eslint-disable-next-line lingui/no-unlocalized-strings
-        eventTimeFormat={hourCycle === 'h12' ? 'hh:mm A' : 'HH:mm'}
+        eventTimeFormat={timeFormat}
         eventDrop={handleEventDrop}
         height="100%"
         themeSystem="standard"
         snapDuration="00:01:00"
         slotLabelInterval="00:60:00"
+        dayHeaderFormat={{ day: 'numeric' }}
+        slotLabelFormat={timeFormat}
         droppable
         drop={handleExternalDrop}
         eventClick={handleEventClick}
@@ -289,8 +325,13 @@ export function ScheduleCalendar() {
               <IconClock size={14} />
             </ThemeIcon>
             <Text size="sm" c="dimmed">
-              {selectedEvent?.start ? formatDateTime(selectedEvent.start) : ''}
+              {selectedEvent?.start ? formatDate(selectedEvent.start) : ''}
             </Text>
+            <TimePicker
+              defaultValue={selectedEvent?.start?.toTimeString() ?? ''}
+              format={hourCycle === 'h12' ? '12h' : '24h'}
+              onChange={handleScheduleTimeChange}
+            />
           </Group>
           {selectedEvent?.start && (
             <Text size="xs" c="dimmed">

--- a/apps/postybirb-ui/src/components/drawers/schedule-drawer/schedule-drawer.css
+++ b/apps/postybirb-ui/src/components/drawers/schedule-drawer/schedule-drawer.css
@@ -17,7 +17,7 @@
 }
 
 :root[data-mantine-color-scheme='dark'] .schedule-drawer-sidebar {
-  border-color: var(--mantine-color-dark-4);
+  border-right-color: var(--mantine-color-dark-4);
   background-color: var(--mantine-color-dark-6);
 }
 
@@ -31,66 +31,107 @@
 
 /* Base light theme styles */
 .schedule-drawer-calendar .fc {
+  /* Base colors */
   --fc-border-color: var(--mantine-color-gray-3);
   --fc-page-bg-color: var(--mantine-color-body);
   --fc-neutral-bg-color: var(--mantine-color-gray-0);
   --fc-neutral-text-color: var(--mantine-color-text);
+
+  /* Button styles (matching Mantine Button) */
   --fc-button-text-color: var(--mantine-color-white);
-  --fc-button-bg-color: var(--mantine-color-blue-6);
-  --fc-button-border-color: var(--mantine-color-blue-6);
-  --fc-button-hover-bg-color: var(--mantine-color-blue-7);
-  --fc-button-hover-border-color: var(--mantine-color-blue-7);
-  --fc-button-active-bg-color: var(--mantine-color-blue-8);
-  --fc-button-active-border-color: var(--mantine-color-blue-8);
-  
-  /* Month/week view */
-  --fc-today-bg-color: var(--mantine-color-blue-0);
-  --fc-highlight-color: var(--mantine-color-blue-1);
+  --fc-button-bg-color: var(--mantine-primary-color-filled);
+  --fc-button-border-color: var(--mantine-primary-color-filled);
+  --fc-button-hover-bg-color: var(--mantine-primary-color-filled-hover);
+  --fc-button-hover-border-color: var(--mantine-primary-color-filled-hover);
+  --fc-button-active-bg-color: var(--mantine-primary-color-filled);
+  --fc-button-active-border-color: var(--mantine-primary-color-filled);
+
+  /* Event styles */
   --fc-event-text-color: var(--mantine-color-white);
-  --fc-event-border-color: var(--mantine-color-blue-6);
-  --fc-event-bg-color: var(--mantine-color-blue-6);
-  
+  --fc-event-border-color: var(--mantine-primary-color-filled);
+  --fc-event-bg-color: var(--mantine-primary-color-filled);
+
+  /* Today & highlight (using Mantine primary color light variants) */
+  --fc-today-bg-color: var(--mantine-primary-color-light);
+  --fc-highlight-color: var(--mantine-primary-color-light-hover);
+
   /* List view */
   --fc-list-event-hover-bg-color: var(--mantine-color-gray-0);
   --fc-theme-standard-list-day-cushion-background: var(--mantine-color-gray-0);
+
+  /* Typography */
+  font-family: var(--mantine-font-family);
+  font-size: var(--mantine-font-size-md);
 }
 
 /* Dark theme overrides */
 :root[data-mantine-color-scheme='dark'] .schedule-drawer-calendar .fc {
   --fc-border-color: var(--mantine-color-dark-4);
-  --fc-page-bg-color: var(--mantine-color-body);
   --fc-neutral-bg-color: var(--mantine-color-dark-6);
-  --fc-neutral-text-color: var(--mantine-color-text);
-  --fc-button-text-color: var(--mantine-color-white);
-  --fc-button-bg-color: var(--mantine-color-blue-6);
-  --fc-button-border-color: var(--mantine-color-blue-6);
-  --fc-button-hover-bg-color: var(--mantine-color-blue-7);
-  --fc-button-hover-border-color: var(--mantine-color-blue-7);
-  --fc-button-active-bg-color: var(--mantine-color-blue-8);
-  --fc-button-active-border-color: var(--mantine-color-blue-8);
-  
-  /* Month/week view */
-  --fc-today-bg-color: rgba(59, 130, 246, 0.1);
-  --fc-highlight-color: rgba(59, 130, 246, 0.2);
-  --fc-event-text-color: var(--mantine-color-white);
-  --fc-event-border-color: var(--mantine-color-blue-6);
-  --fc-event-bg-color: var(--mantine-color-blue-6);
-  
-  /* List view */
   --fc-list-event-hover-bg-color: var(--mantine-color-dark-6);
   --fc-theme-standard-list-day-cushion-background: var(--mantine-color-dark-6);
+  --fc-today-bg-color: var(--mantine-primary-color-light);
+  --fc-highlight-color: var(--mantine-primary-color-light-hover);
 }
 
-/* Text color styles for better Mantine integration */
-.schedule-drawer-calendar .fc-col-header-cell-cushion,
-.schedule-drawer-calendar .fc-daygrid-day-number,
-.schedule-drawer-calendar .fc-list-day-text,
-.schedule-drawer-calendar .fc-list-event-title,
-.schedule-drawer-calendar .fc-list-day-side-text {
-  color: var(--mantine-color-text) !important;
+/* ===== Toolbar & Buttons ===== */
+.schedule-drawer-calendar .fc .fc-toolbar {
+  margin-bottom: var(--mantine-spacing-md);
+  gap: var(--mantine-spacing-sm);
+  flex-wrap: wrap;
 }
 
-/* Table and grid elements */
+.schedule-drawer-calendar .fc .fc-toolbar-title {
+  font-size: var(--mantine-font-size-xl);
+  font-weight: 600;
+  color: var(--mantine-color-text);
+}
+
+/* Mantine‑style buttons */
+.schedule-drawer-calendar .fc .fc-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: var(--mantine-line-height-md);
+  padding: 0 var(--mantine-spacing-sm);
+  font-size: var(--mantine-font-size-sm);
+  font-weight: 500;
+  border-radius: var(--mantine-radius-md);
+  transition: all 0.15s ease;
+  cursor: pointer;
+  background-color: var(--fc-button-bg-color);
+  border: 1px solid var(--fc-button-border-color);
+  color: var(--fc-button-text-color);
+  box-shadow: var(--mantine-shadow-xs);
+}
+
+.schedule-drawer-calendar .fc .fc-button:hover {
+  background-color: var(--fc-button-hover-bg-color);
+  border-color: var(--fc-button-hover-border-color);
+  transform: translateY(-1px);
+  box-shadow: var(--mantine-shadow-sm);
+}
+
+.schedule-drawer-calendar .fc .fc-button:focus-visible {
+  outline: 2px solid var(--mantine-primary-color-filled);
+  outline-offset: 2px;
+}
+
+.schedule-drawer-calendar .fc .fc-button-primary:not(:disabled):active,
+.schedule-drawer-calendar .fc .fc-button-primary.fc-button-active {
+  background-color: var(--fc-button-active-bg-color);
+  border-color: var(--fc-button-active-border-color);
+  transform: translateY(0);
+  box-shadow: var(--mantine-shadow-xs);
+}
+
+/* Button group spacing */
+.schedule-drawer-calendar .fc .fc-button-group > .fc-button {
+  margin: 0 2px;
+  border-radius: var(--mantine-radius-md);
+}
+
+/* ===== Calendar Grid ===== */
 .schedule-drawer-calendar .fc th,
 .schedule-drawer-calendar .fc td,
 .schedule-drawer-calendar .fc .fc-timegrid-slot,
@@ -98,38 +139,84 @@
 .schedule-drawer-calendar .fc .fc-timegrid-axis-cushion,
 .schedule-drawer-calendar .fc .fc-timegrid-axis,
 .schedule-drawer-calendar .fc .fc-col-header-cell {
-  color: var(--mantine-color-text) !important;
   border-color: var(--fc-border-color) !important;
-}
-
-/* Calendar toolbar styling */
-.schedule-drawer-calendar .fc .fc-toolbar {
-  margin-bottom: var(--mantine-spacing-md);
-}
-
-.schedule-drawer-calendar .fc .fc-toolbar-title {
   color: var(--mantine-color-text);
+}
+
+/* Column headers */
+.schedule-drawer-calendar .fc .fc-col-header-cell-cushion {
+  padding: var(--mantine-spacing-xs);
   font-weight: 600;
-  font-size: 1.5rem;
+  color: var(--mantine-color-text);
 }
 
-.schedule-drawer-calendar .fc .fc-button-group > .fc-button {
-  border-radius: var(--mantine-radius-md);
+/* Day numbers */
+.schedule-drawer-calendar .fc .fc-daygrid-day-number {
+  padding: var(--mantine-spacing-xs);
   font-weight: 500;
-  margin: 0 2px;
-  transition: all 0.2s ease;
+  color: var(--mantine-color-text);
+}
+
+/* Today highlight */
+.schedule-drawer-calendar .fc .fc-daygrid-day.fc-day-today {
+  background-color: var(--fc-today-bg-color);
+  border: 1px solid var(--mantine-primary-color-filled);
+  border-radius: var(--mantine-radius-sm);
+}
+
+/* Weekend background (subtle distinction) */
+.schedule-drawer-calendar .fc .fc-daygrid-day.fc-day-sat,
+.schedule-drawer-calendar .fc .fc-daygrid-day.fc-day-sun {
+  background-color: var(--mantine-color-gray-0);
+}
+
+:root[data-mantine-color-scheme='dark']
+  .schedule-drawer-calendar
+  .fc
+  .fc-daygrid-day.fc-day-sat,
+:root[data-mantine-color-scheme='dark']
+  .schedule-drawer-calendar
+  .fc
+  .fc-daygrid-day.fc-day-sun {
+  background-color: var(--mantine-color-dark-7);
+}
+
+/* ===== Events ===== */
+.schedule-drawer-calendar .fc-event {
+  cursor: pointer;
+  transition: all 0.15s ease;
+  border-radius: var(--mantine-radius-sm);
+  border: none;
+  background-color: var(--fc-event-bg-color);
+  color: var(--fc-event-text-color);
+  font-size: var(--mantine-font-size-sm);
+  padding: 2px 6px;
   box-shadow: var(--mantine-shadow-xs);
 }
 
-.schedule-drawer-calendar .fc .fc-button-group > .fc-button:hover {
-  transform: translateY(-1px);
-  box-shadow: var(--mantine-shadow-sm);
+.schedule-drawer-calendar .fc-event:hover {
+  transform: scale(1.01);
+  filter: brightness(0.95);
+  box-shadow: var(--mantine-shadow-md);
+  z-index: var(--mantine-z-index-popover);
 }
 
-.schedule-drawer-calendar .fc .fc-button:not(:disabled):active,
-.schedule-drawer-calendar .fc .fc-button:not(:disabled).fc-button-active {
-  box-shadow: var(--mantine-shadow-xs);
-  transform: none;
+/* Day grid event */
+.schedule-drawer-calendar .fc-daygrid-event {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Time grid event */
+.schedule-drawer-calendar .fc-timegrid-event {
+  padding: 4px 6px;
+}
+
+/* Event resize handle */
+.schedule-drawer-calendar .fc .fc-event-resizer {
+  background-color: var(--mantine-primary-color-filled);
+  border-radius: var(--mantine-radius-xs);
 }
 
 /* Draggable element styles */
@@ -140,14 +227,14 @@
   user-select: none;
   transition: background-color 0.2s ease;
   padding: var(--mantine-spacing-xs);
+  background-color: var(--mantine-primary-color-light);
+  color: var(--mantine-primary-color-light-color);
+  font-weight: 500;
+  margin-bottom: var(--mantine-spacing-xs);
 }
 
 .calendar-draggable:hover {
-  background-color: var(--mantine-color-blue-0);
-}
-
-:root[data-mantine-color-scheme='dark'] .calendar-draggable:hover {
-  background-color: rgba(59, 130, 246, 0.1);
+  background-color: var(--mantine-primary-color-light-hover);
 }
 
 .calendar-draggable:active {
@@ -157,72 +244,19 @@
 /* Dragging state styles */
 .calendar-draggable.fc-event-dragging {
   opacity: 0.8;
-  background-color: var(--mantine-color-blue-1);
+  background-color: var(--mantine-primary-color-light);
   box-shadow: var(--mantine-shadow-lg);
 }
 
-:root[data-mantine-color-scheme='dark'] .calendar-draggable.fc-event-dragging {
-  background-color: rgba(59, 130, 246, 0.2);
+/* List View */
+.schedule-drawer-calendar .fc-list-day-text,
+.schedule-drawer-calendar .fc-list-day-side-text,
+.schedule-drawer-calendar .fc-list-event-title {
+  color: var(--mantine-color-text);
 }
 
-/* FullCalendar event styling */
-.schedule-drawer-calendar .fc-h-event {
-  border-radius: var(--mantine-radius-sm);
-  box-shadow: var(--mantine-shadow-xs);
-  padding: 2px 4px;
-  border: 1px solid var(--fc-event-border-color);
-}
-
-.schedule-drawer-calendar .fc-daygrid-event {
-  border-radius: var(--mantine-radius-sm);
-  padding: 2px 4px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  box-shadow: var(--mantine-shadow-xs);
-}
-
-/* Event hover and interaction effects */
-.schedule-drawer-calendar .fc-event {
-  cursor: pointer;
-  transition: 
-    transform 0.15s ease,
-    box-shadow 0.15s ease,
-    opacity 0.15s ease;
-}
-
-.schedule-drawer-calendar .fc-event:hover {
-  transform: scale(1.02);
-  box-shadow: var(--mantine-shadow-md);
-  z-index: var(--z-section-panel) !important;
-  opacity: 0.95;
-}
-
-/* Today cell highlighting */
-.schedule-drawer-calendar .fc .fc-daygrid-day.fc-day-today {
-  background-color: var(--fc-today-bg-color);
-  border-color: var(--mantine-color-blue-3);
-}
-
-:root[data-mantine-color-scheme='dark'] .schedule-drawer-calendar .fc .fc-daygrid-day.fc-day-today {
-  border-color: var(--mantine-color-blue-7);
-}
-
-/* Weekend styling */
-.schedule-drawer-calendar .fc .fc-daygrid-day.fc-day-sat,
-.schedule-drawer-calendar .fc .fc-daygrid-day.fc-day-sun {
-  background-color: var(--mantine-color-gray-0);
-}
-
-:root[data-mantine-color-scheme='dark'] .schedule-drawer-calendar .fc .fc-daygrid-day.fc-day-sat,
-:root[data-mantine-color-scheme='dark'] .schedule-drawer-calendar .fc .fc-daygrid-day.fc-day-sun {
-  background-color: var(--mantine-color-dark-7);
-}
-
-/* Month view day number styling */
-.schedule-drawer-calendar .fc .fc-daygrid-day-number {
-  padding: var(--mantine-spacing-xs);
-  font-weight: 500;
+.schedule-drawer-calendar .fc-list-event:hover td {
+  background-color: var(--fc-list-event-hover-bg-color);
 }
 
 /* Time grid styling for week/day views */
@@ -235,8 +269,23 @@
   color: var(--mantine-color-dimmed);
 }
 
-/* Event resize handle styling */
-.schedule-drawer-calendar .fc .fc-event-resizer {
-  background-color: var(--mantine-color-blue-6);
-  border-radius: var(--mantine-radius-xs);
+/* ===== Responsive Adjustments ===== */
+@media (max-width: 768px) {
+  .schedule-drawer-content {
+    height: calc(100vh - 80px);
+  }
+
+  .schedule-drawer-sidebar {
+    width: 240px;
+    min-width: 240px;
+  }
+
+  .schedule-drawer-calendar .fc .fc-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .schedule-drawer-calendar .fc .fc-toolbar-title {
+    text-align: center;
+  }
 }

--- a/apps/postybirb-ui/src/components/drawers/schedule-drawer/schedule-drawer.css
+++ b/apps/postybirb-ui/src/components/drawers/schedule-drawer/schedule-drawer.css
@@ -165,23 +165,25 @@
 }
 
 /* Weekend background (subtle distinction) */
-.schedule-drawer-calendar .fc .fc-daygrid-day.fc-day-sat,
-.schedule-drawer-calendar .fc .fc-daygrid-day.fc-day-sun {
-  background-color: var(--mantine-color-gray-0);
+.schedule-drawer-calendar .fc .fc-day-sat .fc-daygrid-day-number,
+.schedule-drawer-calendar .fc .fc-day-sun .fc-daygrid-day-number {
+  color: var(--mantine-color-gray-7);
 }
 
 :root[data-mantine-color-scheme='dark']
   .schedule-drawer-calendar
   .fc
-  .fc-daygrid-day.fc-day-sat,
+  .fc-day-sat
+  .fc-daygrid-day-number,
 :root[data-mantine-color-scheme='dark']
   .schedule-drawer-calendar
   .fc
-  .fc-daygrid-day.fc-day-sun {
-  background-color: var(--mantine-color-dark-7);
+  .fc-day-sun
+  .fc-daygrid-day-number {
+  color: var(--mantine-color-red-6);
 }
 
-/* ===== Events ===== */
+/* Events */
 .schedule-drawer-calendar .fc-event {
   cursor: pointer;
   transition: all 0.15s ease;
@@ -222,19 +224,17 @@
 /* Draggable element styles */
 .calendar-draggable {
   cursor: grab;
-  width: 100%;
-  border-radius: var(--mantine-radius-md);
   user-select: none;
   transition: background-color 0.2s ease;
-  padding: var(--mantine-spacing-xs);
-  background-color: var(--mantine-primary-color-light);
-  color: var(--mantine-primary-color-light-color);
-  font-weight: 500;
-  margin-bottom: var(--mantine-spacing-xs);
+}
+
+:root[data-mantine-color-scheme='light'] .calendar-draggable {
+  box-shadow: var(--paper-shadow);
+  border-radius: var(--paper-radius);
 }
 
 .calendar-draggable:hover {
-  background-color: var(--mantine-primary-color-light-hover);
+  border-color: var(--mantine-primary-color-filled);
 }
 
 .calendar-draggable:active {

--- a/apps/postybirb-ui/src/components/drawers/schedule-drawer/submission-list.tsx
+++ b/apps/postybirb-ui/src/components/drawers/schedule-drawer/submission-list.tsx
@@ -6,7 +6,7 @@
 import { Draggable } from '@fullcalendar/interaction';
 import { Trans, useLingui } from '@lingui/react/macro';
 import {
-  Box,
+  Card,
   Group,
   ScrollArea,
   Stack,
@@ -35,7 +35,10 @@ function DraggableSubmissionItem({
   const isMessage = submission.type === SubmissionType.MESSAGE;
 
   return (
-    <Box
+    <Card
+      withBorder
+      p="sm"
+      radius="sm"
       className="calendar-draggable"
       data-submission-id={submission.id}
       style={{
@@ -55,7 +58,7 @@ function DraggableSubmissionItem({
           {title}
         </Text>
       </Group>
-    </Box>
+    </Card>
   );
 }
 

--- a/apps/postybirb-ui/src/components/language-picker/language-picker.css
+++ b/apps/postybirb-ui/src/components/language-picker/language-picker.css
@@ -17,5 +17,5 @@
 }
 
 .postybirb__language_picker_item--selected {
-  background-color: var(--mantine-color-blue-light);
+  background-color: var(--mantine-primary-color-light);
 }

--- a/apps/postybirb-ui/src/components/language-picker/language-picker.tsx
+++ b/apps/postybirb-ui/src/components/language-picker/language-picker.tsx
@@ -34,7 +34,10 @@ interface LanguagePickerProps {
 /**
  * Renders a language picker as a NavLink-style component with a popup menu.
  */
-export function LanguagePicker({ collapsed = false, kbd }: LanguagePickerProps) {
+export function LanguagePicker({
+  collapsed = false,
+  kbd,
+}: LanguagePickerProps) {
   const { t } = useLingui();
   const { language: locale, setLanguage: setLocale } = useLanguageActions();
   const [opened, { toggle, close }] = useDisclosure(false);
@@ -75,7 +78,9 @@ export function LanguagePicker({ collapsed = false, kbd }: LanguagePickerProps) 
           <Tooltip
             label={
               <Box className="postybirb__tooltip_content">
-                <span><Trans>Language</Trans></span>
+                <span>
+                  <Trans>Language</Trans>
+                </span>
                 {kbd && (
                   <Kbd size="xs" className="postybirb__kbd_aligned">
                     {formatKeybindingDisplay(kbd)}
@@ -102,7 +107,6 @@ export function LanguagePicker({ collapsed = false, kbd }: LanguagePickerProps) 
             <Badge
               size="xs"
               variant="filled"
-              color="blue"
               className="postybirb__language_picker_badge"
             >
               {locale}
@@ -132,7 +136,11 @@ export function LanguagePicker({ collapsed = false, kbd }: LanguagePickerProps) 
               }}
               onMouseEnter={() => setHoveredLang(value)}
               onMouseLeave={() => setHoveredLang(null)}
-              color={isActive || isHovered ? 'blue' : undefined}
+              color={
+                isActive || isHovered
+                  ? 'var(--mantine-primary-color-6)'
+                  : undefined
+              }
               fw={isActive ? 500 : undefined}
             >
               {t(label)}

--- a/apps/postybirb-ui/src/components/sections/submissions-section/submission-edit-card/account-selection/form/fields/datetime-field.tsx
+++ b/apps/postybirb-ui/src/components/sections/submissions-section/submission-edit-card/account-selection/form/fields/datetime-field.tsx
@@ -5,8 +5,8 @@
 import { DateTimeFieldType } from '@postybirb/form-builder';
 import { IconCalendar } from '@tabler/icons-react';
 import dayjs from 'dayjs';
-import { useLocale } from '../../../../../../../hooks/use-locale.js';
-import { DateTimePickerWithLocalization } from '../../../../../../shared/index.js';
+import { useLocale } from '../../../../../../../hooks/use-locale';
+import { DateTimePickerWithLocalization } from '../../../../../../shared/index';
 import { useFormFieldsContext } from '../form-fields-context';
 import { useDefaultOption } from '../hooks/use-default-option';
 import { useValidations } from '../hooks/use-validations';

--- a/apps/postybirb-ui/src/components/sections/submissions-section/submission-edit-card/account-selection/form/fields/datetime-field.tsx
+++ b/apps/postybirb-ui/src/components/sections/submissions-section/submission-edit-card/account-selection/form/fields/datetime-field.tsx
@@ -2,10 +2,11 @@
  * DateTimeField - Date/time picker field.
  */
 
-import { DateTimePicker } from '@mantine/dates';
 import { DateTimeFieldType } from '@postybirb/form-builder';
 import { IconCalendar } from '@tabler/icons-react';
-import moment from 'moment';
+import dayjs from 'dayjs';
+import { useLocale } from '../../../../../../../hooks/use-locale.js';
+import { DateTimePickerWithLocalization } from '../../../../../../shared/index.js';
 import { useFormFieldsContext } from '../form-fields-context';
 import { useDefaultOption } from '../hooks/use-default-option';
 import { useValidations } from '../hooks/use-validations';
@@ -20,31 +21,31 @@ function DateTimePickerField({
   const { getValue, setValue, submission } = useFormFieldsContext();
 
   const value = getValue<string>(fieldName) ?? field.defaultValue ?? '';
-  const dateValue = value ? moment(value).toDate() : null;
+  const dateValue = value ? dayjs(value).toDate() : null;
 
-  const minDate = field.min ? moment(field.min).toDate() : undefined;
-  const maxDate = field.max ? moment(field.max).toDate() : undefined;
+  const minDate = field.min ? dayjs(field.min).toDate() : undefined;
+  const maxDate = field.max ? dayjs(field.max).toDate() : undefined;
+
+  const { dayjsDateTimeFormat: dateTimeFormat } = useLocale();
+
+  const format = field.format || dateTimeFormat;
 
   return (
-    <DateTimePicker
+    <DateTimePickerWithLocalization
       rightSection={<IconCalendar />}
       value={dateValue}
       disabled={submission.isArchived}
+      valueFormat={format}
       onChange={(date) => {
         if (date) {
-          setValue(fieldName, moment(date).toISOString());
+          setValue(fieldName, date);
         } else {
           setValue(fieldName, '');
         }
       }}
       placeholder={
-        defaultValue
-          ? // eslint-disable-next-line lingui/no-unlocalized-strings
-            moment(defaultValue).format(field.format || 'YYYY-MM-DD HH:mm')
-          : undefined
+        defaultValue ? dayjs(defaultValue).format(format) : undefined
       }
-      // eslint-disable-next-line lingui/no-unlocalized-strings
-      valueFormat={field.format || 'YYYY-MM-DD HH:mm'}
       withSeconds={false}
       minDate={minDate}
       maxDate={maxDate}

--- a/apps/postybirb-ui/src/components/sections/submissions-section/submission-edit-card/schedule-form/schedule-form.tsx
+++ b/apps/postybirb-ui/src/components/sections/submissions-section/submission-edit-card/schedule-form/schedule-form.tsx
@@ -17,7 +17,7 @@ import {
 import { ISubmissionScheduleInfo, ScheduleType } from '@postybirb/types';
 import { IconCalendar, IconCalendarOff, IconRepeat } from '@tabler/icons-react';
 import { Cron } from 'croner';
-import moment from 'dayjs';
+import dayjs from 'dayjs';
 import { useCallback, useEffect, useState } from 'react';
 import { useLocalStorage } from 'react-use';
 import { useLocale } from '../../../../../hooks';
@@ -83,7 +83,7 @@ export function ScheduleForm({
           if (lastUsedDate && new Date(lastUsedDate) > new Date()) {
             scheduledFor = lastUsedDate;
           } else {
-            scheduledFor = moment()
+            scheduledFor = dayjs()
               .add(1, 'day')
               .hour(9)
               .minute(0)

--- a/apps/postybirb-ui/src/components/sections/submissions-section/submission-edit-card/schedule-form/schedule-form.tsx
+++ b/apps/postybirb-ui/src/components/sections/submissions-section/submission-edit-card/schedule-form/schedule-form.tsx
@@ -21,7 +21,7 @@ import moment from 'dayjs';
 import { useCallback, useEffect, useState } from 'react';
 import { useLocalStorage } from 'react-use';
 import { useLocale } from '../../../../../hooks';
-import { DateTimePickerWithLocalization } from '../../../../shared/index.js';
+import { DateTimePickerWithLocalization } from '../../../../shared/index';
 import { CronPicker } from '../../../../shared/schedule-popover/cron-picker';
 
 export interface ScheduleFormProps {

--- a/apps/postybirb-ui/src/components/sections/submissions-section/submission-edit-card/schedule-form/schedule-form.tsx
+++ b/apps/postybirb-ui/src/components/sections/submissions-section/submission-edit-card/schedule-form/schedule-form.tsx
@@ -4,15 +4,24 @@
  */
 
 import { Trans } from '@lingui/react/macro';
-import { Box, Group, Paper, Stack, Switch, Tabs, Text, Title } from '@mantine/core';
-import { DateTimePicker, DateValue } from '@mantine/dates';
+import {
+  Box,
+  Group,
+  Paper,
+  Stack,
+  Switch,
+  Tabs,
+  Text,
+  Title,
+} from '@mantine/core';
 import { ISubmissionScheduleInfo, ScheduleType } from '@postybirb/types';
 import { IconCalendar, IconCalendarOff, IconRepeat } from '@tabler/icons-react';
 import { Cron } from 'croner';
-import moment from 'moment';
+import moment from 'dayjs';
 import { useCallback, useEffect, useState } from 'react';
 import { useLocalStorage } from 'react-use';
 import { useLocale } from '../../../../../hooks';
+import { DateTimePickerWithLocalization } from '../../../../shared/index.js';
 import { CronPicker } from '../../../../shared/schedule-popover/cron-picker';
 
 export interface ScheduleFormProps {
@@ -38,7 +47,11 @@ export function ScheduleForm({
   onChange,
   disabled = false,
 }: ScheduleFormProps) {
-  const { formatRelativeTime } = useLocale();
+  const {
+    formatRelativeTime,
+    dayjsDateTimeFormat: dateTimeFormat,
+    startOfWeek,
+  } = useLocale();
   const [internalSchedule, setInternalSchedule] =
     useState<ISubmissionScheduleInfo>(schedule);
   const [internalIsScheduled, setInternalIsScheduled] =
@@ -112,10 +125,10 @@ export function ScheduleForm({
 
   // Handle date/time change for single schedule
   const handleDateTimeChange = useCallback(
-    (date: DateValue) => {
+    (date: Date | null) => {
       if (!date) return;
-      // DateValue can be Date or string, convert to ISO string
-      const scheduledFor = date instanceof Date ? date.toISOString() : new Date(date).toISOString();
+
+      const scheduledFor = date.toISOString();
       const newSchedule: ISubmissionScheduleInfo = {
         ...internalSchedule,
         scheduledFor,
@@ -229,13 +242,10 @@ export function ScheduleForm({
 
           <Tabs.Panel value={ScheduleType.SINGLE} pl="md">
             <Stack gap="sm">
-              <DateTimePicker
+              <DateTimePickerWithLocalization
                 label={<Trans>Date and Time</Trans>}
                 size="sm"
                 clearable={false}
-                // eslint-disable-next-line lingui/no-unlocalized-strings
-                valueFormat="YYYY-MM-DD HH:mm"
-                highlightToday
                 minDate={new Date()}
                 value={scheduledDate}
                 disabled={disabled}
@@ -262,7 +272,9 @@ export function ScheduleForm({
               <Box
                 // CronPicker does not support a disabled prop, so we use
                 // pointer-events to prevent interaction when archived.
-                style={disabled ? { pointerEvents: 'none', opacity: 0.6 } : undefined}
+                style={
+                  disabled ? { pointerEvents: 'none', opacity: 0.6 } : undefined
+                }
               >
                 <CronPicker
                   value={internalSchedule.cron || DEFAULT_CRON}

--- a/apps/postybirb-ui/src/components/sections/templates-section/templates-section.css
+++ b/apps/postybirb-ui/src/components/sections/templates-section/templates-section.css
@@ -16,10 +16,10 @@
 }
 
 .postybirb__templates__card:hover {
-  background-color: var(--mantine-color-dark-5);
+  border-color: var(--mantine-primary-color-filled);
 }
 
 .postybirb__templates__card--selected {
   border-color: var(--mantine-primary-color-filled);
-  background-color: var(--mantine-color-dark-6);
+  background-color: var(--mantine-primary-color-light-hover);
 }

--- a/apps/postybirb-ui/src/components/shared/date-time-picker-with-localization/date-time-picker-with-localization.tsx
+++ b/apps/postybirb-ui/src/components/shared/date-time-picker-with-localization/date-time-picker-with-localization.tsx
@@ -1,6 +1,6 @@
 import { DateTimePicker, DateTimePickerProps, DayOfWeek } from '@mantine/dates';
 import dayjs from 'dayjs';
-import { useLocale } from '../../../hooks/use-locale.js';
+import { useLocale } from '../../../hooks/use-locale';
 
 type Props = Omit<DateTimePickerProps, 'onChange'> & {
   onChange(date: Date | null): void;

--- a/apps/postybirb-ui/src/components/shared/date-time-picker-with-localization/date-time-picker-with-localization.tsx
+++ b/apps/postybirb-ui/src/components/shared/date-time-picker-with-localization/date-time-picker-with-localization.tsx
@@ -1,0 +1,30 @@
+import { DateTimePicker, DateTimePickerProps, DayOfWeek } from '@mantine/dates';
+import dayjs from 'dayjs';
+import { useLocale } from '../../../hooks/use-locale.js';
+
+type Props = Omit<DateTimePickerProps, 'onChange'> & {
+  onChange(date: Date | null): void;
+};
+
+export function DateTimePickerWithLocalization(props: Props) {
+  const { startOfWeek, dayjsDateTimeFormat, hourCycle } = useLocale();
+  const { onChange, valueFormat } = props;
+  const format = valueFormat ?? dayjsDateTimeFormat;
+
+  return (
+    <DateTimePicker
+      highlightToday
+      firstDayOfWeek={startOfWeek as DayOfWeek}
+      valueFormat={format}
+      timePickerProps={{ format: hourCycle === 'h12' ? '12h' : '24h' }}
+      {...props}
+      onChange={(value) => {
+        if (value) {
+          onChange(dayjs(value, format).toDate());
+        } else {
+          onChange(null);
+        }
+      }}
+    />
+  );
+}

--- a/apps/postybirb-ui/src/components/shared/description-editor/description-editor.tsx
+++ b/apps/postybirb-ui/src/components/shared/description-editor/description-editor.tsx
@@ -44,7 +44,7 @@ import { PluginKey } from '@tiptap/pm/state';
 import { Editor, EditorContent, ReactRenderer, useEditor } from '@tiptap/react';
 import Suggestion from '@tiptap/suggestion';
 import { useCallback, useMemo, useRef } from 'react';
-import tippy, { type Instance as TippyInstance } from 'tippy';
+import tippy, { type Instance as TippyInstance } from 'tippy.js';
 
 import { useCustomShortcuts } from '../../../stores/entity/custom-shortcut-store';
 import { useWebsites } from '../../../stores/entity/website-store';

--- a/apps/postybirb-ui/src/components/shared/description-editor/description-editor.tsx
+++ b/apps/postybirb-ui/src/components/shared/description-editor/description-editor.tsx
@@ -44,7 +44,7 @@ import { PluginKey } from '@tiptap/pm/state';
 import { Editor, EditorContent, ReactRenderer, useEditor } from '@tiptap/react';
 import Suggestion from '@tiptap/suggestion';
 import { useCallback, useMemo, useRef } from 'react';
-import tippy, { type Instance as TippyInstance } from 'tippy.js';
+import tippy, { type Instance as TippyInstance } from 'tippy';
 
 import { useCustomShortcuts } from '../../../stores/entity/custom-shortcut-store';
 import { useWebsites } from '../../../stores/entity/website-store';

--- a/apps/postybirb-ui/src/components/shared/index.ts
+++ b/apps/postybirb-ui/src/components/shared/index.ts
@@ -15,6 +15,10 @@ export { SearchInput } from './search-input';
 export { SimpleTagInput } from './simple-tag-input';
 export type { SimpleTagInputProps } from './simple-tag-input';
 export { SubmissionPicker, SubmissionPickerModal } from './submission-picker';
-export type { SubmissionPickerProps, SubmissionPickerModalProps } from './submission-picker';
+export type {
+  SubmissionPickerModalProps,
+  SubmissionPickerProps,
+} from './submission-picker';
 export { TemplatePicker } from './template-picker/template-picker';
 
+export { DateTimePickerWithLocalization } from './date-time-picker-with-localization/date-time-picker-with-localization';

--- a/apps/postybirb-ui/src/components/shared/multi-scheduler-modal/multi-scheduler-modal.tsx
+++ b/apps/postybirb-ui/src/components/shared/multi-scheduler-modal/multi-scheduler-modal.tsx
@@ -27,7 +27,7 @@ import {
   showErrorNotification,
   showSuccessNotification,
 } from '../../../utils/notifications';
-import { DateTimePickerWithLocalization } from '../date-time-picker-with-localization/date-time-picker-with-localization.js';
+import { DateTimePickerWithLocalization } from '../date-time-picker-with-localization/date-time-picker-with-localization';
 import { ReorderableSubmissionList } from '../reorderable-submission-list';
 import './multi-scheduler-modal.css';
 

--- a/apps/postybirb-ui/src/components/shared/multi-scheduler-modal/multi-scheduler-modal.tsx
+++ b/apps/postybirb-ui/src/components/shared/multi-scheduler-modal/multi-scheduler-modal.tsx
@@ -16,7 +16,6 @@ import {
   Text,
   Title,
 } from '@mantine/core';
-import { DateTimePicker } from '@mantine/dates';
 import { ScheduleType } from '@postybirb/types';
 import { IconCalendarEvent } from '@tabler/icons-react';
 import { useCallback, useMemo, useState } from 'react';
@@ -28,6 +27,7 @@ import {
   showErrorNotification,
   showSuccessNotification,
 } from '../../../utils/notifications';
+import { DateTimePickerWithLocalization } from '../date-time-picker-with-localization/date-time-picker-with-localization.js';
 import { ReorderableSubmissionList } from '../reorderable-submission-list';
 import './multi-scheduler-modal.css';
 
@@ -73,7 +73,11 @@ export function MultiSchedulerModal({
   submissions: initialSubmissions,
 }: MultiSchedulerModalProps) {
   const { t } = useLingui();
-  const { formatDateTime } = useLocale();
+  const {
+    formatDateTime,
+    dayjsDateTimeFormat: dateTimeFormat,
+    startOfWeek,
+  } = useLocale();
 
   // Reorderable submissions state
   const [orderedSubmissions, setOrderedSubmissions] =
@@ -109,13 +113,7 @@ export function MultiSchedulerModal({
 
   // Handle date change
   const handleDateChange = useCallback(
-    (value: Date | string | null) => {
-      // DateTimePicker may pass string or Date
-      const date = value
-        ? typeof value === 'string'
-          ? new Date(value)
-          : value
-        : null;
+    (date: Date | null) => {
       setSelectedDate(date);
       if (date && !Number.isNaN(date.getTime())) {
         setLastUsedDate(date.toISOString());
@@ -237,9 +235,7 @@ export function MultiSchedulerModal({
             <Trans>Schedule Settings</Trans>
           </Text>
           <Stack gap="md">
-            <DateTimePicker
-              // eslint-disable-next-line lingui/no-unlocalized-strings
-              valueFormat="YYYY-MM-DD HH:mm"
+            <DateTimePickerWithLocalization
               label={<Trans>Start Date</Trans>}
               value={selectedDate}
               onChange={handleDateChange}
@@ -249,9 +245,7 @@ export function MultiSchedulerModal({
             />
 
             <Text size="xs" c="dimmed">
-              <Trans>
-                Set the interval between each submission.
-              </Trans>
+              <Trans>Set the interval between each submission.</Trans>
             </Text>
 
             <Group grow>

--- a/apps/postybirb-ui/src/components/shared/schedule-popover/schedule-popover.tsx
+++ b/apps/postybirb-ui/src/components/shared/schedule-popover/schedule-popover.tsx
@@ -28,7 +28,7 @@ import { Cron } from 'croner';
 import dayjs from 'dayjs';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocalStorage } from 'react-use';
-import { DateTimePickerWithLocalization } from '../date-time-picker-with-localization/date-time-picker-with-localization.js';
+import { DateTimePickerWithLocalization } from '../date-time-picker-with-localization/date-time-picker-with-localization';
 import { CronPicker } from './cron-picker';
 
 export interface SchedulePopoverProps {

--- a/apps/postybirb-ui/src/components/shared/schedule-popover/schedule-popover.tsx
+++ b/apps/postybirb-ui/src/components/shared/schedule-popover/schedule-popover.tsx
@@ -15,7 +15,6 @@ import {
   Text,
   Tooltip,
 } from '@mantine/core';
-import { DateTimePicker } from '@mantine/dates';
 import { useDisclosure } from '@mantine/hooks';
 import { ISubmissionScheduleInfo, ScheduleType } from '@postybirb/types';
 import {
@@ -26,9 +25,10 @@ import {
   IconX,
 } from '@tabler/icons-react';
 import { Cron } from 'croner';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocalStorage } from 'react-use';
+import { DateTimePickerWithLocalization } from '../date-time-picker-with-localization/date-time-picker-with-localization.js';
 import { CronPicker } from './cron-picker';
 
 export interface SchedulePopoverProps {
@@ -90,7 +90,7 @@ export function SchedulePopover({
           if (lastUsedDate && new Date(lastUsedDate) > new Date()) {
             scheduledFor = lastUsedDate;
           } else {
-            scheduledFor = moment()
+            scheduledFor = dayjs()
               .add(1, 'day')
               .hour(9)
               .minute(0)
@@ -331,29 +331,19 @@ export function SchedulePopover({
           {/* Single schedule - Date picker */}
           {internalSchedule.scheduleType === ScheduleType.SINGLE && (
             <Box>
-              <DateTimePicker
+              <DateTimePickerWithLocalization
                 label={<Trans>Date and Time</Trans>}
                 size="xs"
                 clearable={false}
-                // eslint-disable-next-line lingui/no-unlocalized-strings
-                valueFormat="YYYY-MM-DD HH:mm"
-                highlightToday
                 minDate={new Date()}
                 value={scheduledDate}
-                onChange={(value) => {
-                  // DateTimePicker returns string when valueFormat is specified
-                  if (value) {
-                    handleDateChange(new Date(value));
-                  } else {
-                    handleDateChange(null);
-                  }
-                }}
+                onChange={handleDateChange}
                 error={isDateInPast ? <Trans>Date is in the past</Trans> : null}
                 popoverProps={{ withinPortal: true }}
               />
               {scheduledDate && !isDateInPast && (
                 <Text size="xs" c="dimmed" mt={4}>
-                  {moment(scheduledDate).fromNow()}
+                  {dayjs(scheduledDate).fromNow()}
                 </Text>
               )}
             </Box>

--- a/apps/postybirb-ui/src/hooks/use-locale.ts
+++ b/apps/postybirb-ui/src/hooks/use-locale.ts
@@ -13,7 +13,7 @@ import {
   cronstrueLocaleMap,
   dateLocaleMap,
 } from '../i18n/languages';
-import { useLocaleStore } from '../stores/ui/locale-store.js';
+import { useLocaleStore } from '../stores/ui/locale-store';
 
 dayjs.extend(relativeTime);
 dayjs.extend(customParseFormat);

--- a/apps/postybirb-ui/src/hooks/use-locale.ts
+++ b/apps/postybirb-ui/src/hooks/use-locale.ts
@@ -4,14 +4,19 @@
  * Auto-subscribes to locale changes via lingui.
  */
 
-import { useLingui } from '@lingui/react';
-import moment from 'moment/min/moment-with-locales';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+import relativeTime from 'dayjs/plugin/relativeTime';
 import { useEffect, useMemo } from 'react';
 import {
-    calendarLanguageMap,
-    cronstrueLocaleMap,
-    dateLocaleMap,
+  calendarLanguageMap,
+  cronstrueLocaleMap,
+  dateLocaleMap,
 } from '../i18n/languages';
+import { useLocaleStore } from '../stores/ui/locale-store.js';
+
+dayjs.extend(relativeTime);
+dayjs.extend(customParseFormat);
 
 /**
  * Return type for the useLocale hook.
@@ -19,28 +24,48 @@ import {
 export interface UseLocaleResult {
   /** Current app locale code (e.g., 'en', 'de', 'pt-BR') */
   locale: string;
+
   /** Locale code for date libraries (dayjs/moment) */
   dateLocale: string;
+
   /** Locale code for FullCalendar */
-  calendarLocale: string;
+  calendarLocale: string | object;
+
   /** Locale code for cronstrue */
   cronstrueLocale: string;
+
+  /** From 0 to 6, Sunday = 0, Monday = 1, Saturday = 6 */
+  startOfWeek: number;
+
+  hourCycle: Intl.LocaleHourCycleKey;
+
+  /** Default value for current locale */
+  defaultStartOfWeek: number;
+
+  /** Default value for current locale */
+  defaultHourCycle: Intl.LocaleHourCycleKey;
+
+  dayjsDateTimeFormat: string;
+
   /** Format a date as relative time (e.g., "2 hours ago", "in 3 days") */
   formatRelativeTime: (date: Date | string) => string;
+
   /** Format a date/time for display using locale-aware formatting */
   formatDateTime: (
     date: Date | string,
-    options?: Intl.DateTimeFormatOptions
+    options?: Intl.DateTimeFormatOptions,
   ) => string;
+
   /** Format a date only (no time) for display */
   formatDate: (
     date: Date | string,
-    options?: Intl.DateTimeFormatOptions
+    options?: Intl.DateTimeFormatOptions,
   ) => string;
+
   /** Format a time only (no date) for display */
   formatTime: (
     date: Date | string,
-    options?: Intl.DateTimeFormatOptions
+    options?: Intl.DateTimeFormatOptions,
   ) => string;
 }
 
@@ -78,27 +103,45 @@ const DEFAULT_TIME_OPTIONS: Intl.DateTimeFormatOptions = {
  * ```
  */
 export function useLocale(): UseLocaleResult {
-  const { i18n } = useLingui();
-  const locale = i18n.locale || 'en';
+  const store = useLocaleStore();
+  const locale = store.language;
 
   // Map the app locale to library-specific locale codes
   const dateLocale = dateLocaleMap[locale] || locale;
   const calendarLocale = calendarLanguageMap[locale] || 'en-US';
   const cronstrueLocale = cronstrueLocaleMap[locale] || 'en';
 
+  const defaultLocaleInfo = useMemo(() => getLocaleInfo(locale), [locale]);
+
+  const startOfWeek =
+    store.startOfWeek === 'locale'
+      ? defaultLocaleInfo.startOfWeek
+      : store.startOfWeek;
+  const hourCycle =
+    store.hourCycle === 'locale'
+      ? defaultLocaleInfo.hourCycle
+      : store.hourCycle;
+
+  const dayjsDateTimeFormat =
+    // eslint-disable-next-line lingui/no-unlocalized-strings
+    hourCycle === 'h24' ? 'YYYY-MM-DD HH:mm' : 'YYYY-MM-DD hh:mm A';
+
   // Set moment locale as a proper side effect (not inside useMemo)
   useEffect(() => {
-    moment.locale(dateLocale);
+    dayjs.locale(dateLocale);
   }, [dateLocale]);
 
   // Memoize the formatting functions to avoid recreating on each render
   const formatters = useMemo(() => {
     const formatRelativeTime = (date: Date | string): string =>
-      moment(date).fromNow();
+      dayjs(date).fromNow();
 
     const formatDateTime = (
       date: Date | string,
-      options: Intl.DateTimeFormatOptions = DEFAULT_DATETIME_OPTIONS
+      options: Intl.DateTimeFormatOptions = {
+        ...DEFAULT_DATETIME_OPTIONS,
+        hourCycle,
+      },
     ): string => {
       const d = typeof date === 'string' ? new Date(date) : date;
       return d.toLocaleString(locale, options);
@@ -106,7 +149,7 @@ export function useLocale(): UseLocaleResult {
 
     const formatDate = (
       date: Date | string,
-      options: Intl.DateTimeFormatOptions = DEFAULT_DATE_OPTIONS
+      options: Intl.DateTimeFormatOptions = DEFAULT_DATE_OPTIONS,
     ): string => {
       const d = typeof date === 'string' ? new Date(date) : date;
       return d.toLocaleDateString(locale, options);
@@ -114,20 +157,56 @@ export function useLocale(): UseLocaleResult {
 
     const formatTime = (
       date: Date | string,
-      options: Intl.DateTimeFormatOptions = DEFAULT_TIME_OPTIONS
+      options: Intl.DateTimeFormatOptions = {
+        ...DEFAULT_TIME_OPTIONS,
+        hourCycle,
+      },
     ): string => {
       const d = typeof date === 'string' ? new Date(date) : date;
       return d.toLocaleTimeString(locale, options);
     };
 
     return { formatRelativeTime, formatDateTime, formatDate, formatTime };
-  }, [locale]);
+  }, [locale, hourCycle]);
 
   return {
+    startOfWeek,
+    hourCycle,
+    defaultHourCycle: defaultLocaleInfo.hourCycle,
+    defaultStartOfWeek: defaultLocaleInfo.startOfWeek,
+    dayjsDateTimeFormat,
     locale,
     dateLocale,
     calendarLocale,
     cronstrueLocale,
     ...formatters,
   };
+}
+
+function getLocaleInfo(locale: string) {
+  try {
+    const intlLocale = new Intl.Locale(locale);
+
+    // @ts-expect-error typings were included into typescript 6.0
+    const weekInfo = intlLocale.getWeekInfo() as WeekInfo;
+
+    return {
+      // % 7 Converts a first-day-of-week value from Monday-based (1–7) to Sunday-based (0–6)
+      startOfWeek: weekInfo.firstDay % 7,
+      hourCycle: intlLocale.hourCycle ?? 'h24',
+    };
+  } catch (e) {
+    // eslint-disable-next-line lingui/no-unlocalized-strings, no-console
+    console.error('Failed to get locale info', e);
+    return {
+      startOfWeek: 0,
+      hourCycle: 'h24' as const,
+    };
+  }
+}
+
+interface WeekInfo {
+  firstDay: number; // 1 (Monday) to 7 (Sunday)
+  weekend: number[]; // Days of the weekend (e.g., [6, 7])
+  minimalDays: number; // Minimal days for the first week of the year (1-7)
 }

--- a/apps/postybirb-ui/src/hooks/use-locale.ts
+++ b/apps/postybirb-ui/src/hooks/use-locale.ts
@@ -25,7 +25,7 @@ export interface UseLocaleResult {
   /** Current app locale code (e.g., 'en', 'de', 'pt-BR') */
   locale: string;
 
-  /** Locale code for date libraries (dayjs/moment) */
+  /** Locale code for date libraries (dayjs) */
   dateLocale: string;
 
   /** Locale code for FullCalendar */
@@ -126,7 +126,7 @@ export function useLocale(): UseLocaleResult {
     // eslint-disable-next-line lingui/no-unlocalized-strings
     hourCycle === 'h24' ? 'YYYY-MM-DD HH:mm' : 'YYYY-MM-DD hh:mm A';
 
-  // Set moment locale as a proper side effect (not inside useMemo)
+  // Set dayjs locale as a proper side effect (not inside useMemo)
   useEffect(() => {
     dayjs.locale(dateLocale);
   }, [dateLocale]);

--- a/apps/postybirb-ui/src/i18n/languages.tsx
+++ b/apps/postybirb-ui/src/i18n/languages.tsx
@@ -1,14 +1,23 @@
 import { msg } from '@lingui/core/macro';
+
 import 'cronstrue/locales/de';
 import 'cronstrue/locales/es';
 import 'cronstrue/locales/pt_BR';
 import 'cronstrue/locales/ru';
+
 import 'dayjs/locale/de';
 import 'dayjs/locale/es';
 import 'dayjs/locale/lt';
 import 'dayjs/locale/pt-br';
 import 'dayjs/locale/ru';
 import 'dayjs/locale/ta';
+
+import calendarDE from '@fullcalendar/core/locales/de';
+import calendarES from '@fullcalendar/core/locales/es';
+import calendarLT from '@fullcalendar/core/locales/lt';
+import calendarPT_BR from '@fullcalendar/core/locales/pt-br';
+import calendarRU from '@fullcalendar/core/locales/ru';
+import calendarTA from '@fullcalendar/core/locales/ta-in';
 
 export const languages = [
   [msg`English`, 'en'],
@@ -32,14 +41,14 @@ export const dateLocaleMap: Record<string, string> = {
   ta: 'ta',
 };
 
-export const calendarLanguageMap: Record<string, string> = {
-  'pt-BR': 'pt-br',
+export const calendarLanguageMap: Record<string, string | object> = {
+  'pt-BR': calendarPT_BR,
   en: 'en-US',
-  de: 'de-DE',
-  lt: 'lt-LT',
-  ru: 'ru-RU',
-  es: 'pt-BR',
-  ta: 'ta-IN',
+  de: calendarDE,
+  lt: calendarLT,
+  ru: calendarRU,
+  es: calendarES,
+  ta: calendarTA,
 };
 
 /**

--- a/apps/postybirb-ui/src/providers/i18n-provider.tsx
+++ b/apps/postybirb-ui/src/providers/i18n-provider.tsx
@@ -8,7 +8,7 @@ import { i18n } from '@lingui/core';
 import { I18nProvider as LinguiI18nProvider } from '@lingui/react';
 import { Group, Loader } from '@mantine/core';
 import { DatesProvider } from '@mantine/dates';
-import moment from 'moment/min/moment-with-locales';
+import dayjs from 'dayjs';
 import { useCallback, useEffect, useState } from 'react';
 import { useLanguage } from '../stores/ui/locale-store';
 
@@ -30,7 +30,7 @@ export function I18nProvider({ children }: { children: React.ReactNode }) {
     lang = lang ?? 'en';
     const { messages } = await import(`../../../../lang/${lang}.po`);
     i18n.loadAndActivate({ locale: lang, messages });
-    moment.locale(lang);
+    dayjs.locale(lang);
     setLoaded(true);
   }, []);
 
@@ -70,7 +70,9 @@ export function I18nProvider({ children }: { children: React.ReactNode }) {
       <Loader />
       <div>Loading translations...</div>
       {tooLongLoading && (
-        <div>Loading takes too much time, please check the console for errors.</div>
+        <div>
+          Loading takes too much time, please check the console for errors.
+        </div>
       )}
     </Group>
   );

--- a/apps/postybirb-ui/src/stores/entity/settings-store.ts
+++ b/apps/postybirb-ui/src/stores/entity/settings-store.ts
@@ -59,23 +59,28 @@ export const useSettingsOptions = () =>
 /**
  * Select specific settings values.
  */
-export const useLanguage = () =>
-  useSettingsStore((state: SettingsStore) => state.records[0]?.language);
-
 export const useQueuePaused = () =>
-  useSettingsStore((state: SettingsStore) => state.records[0]?.queuePaused ?? false);
+  useSettingsStore(
+    (state: SettingsStore) => state.records[0]?.queuePaused ?? false,
+  );
 
 export const useHiddenWebsites = () =>
-  useSettingsStore((state: SettingsStore) => state.records[0]?.hiddenWebsites ?? []);
+  useSettingsStore(
+    (state: SettingsStore) => state.records[0]?.hiddenWebsites ?? [],
+  );
 
 export const useAllowAd = () =>
   useSettingsStore((state: SettingsStore) => state.records[0]?.allowAd ?? true);
 
 export const useDesktopNotifications = () =>
-  useSettingsStore((state: SettingsStore) => state.records[0]?.desktopNotifications);
+  useSettingsStore(
+    (state: SettingsStore) => state.records[0]?.desktopNotifications,
+  );
 
 export const useTagSearchProvider = () =>
-  useSettingsStore((state: SettingsStore) => state.records[0]?.tagSearchProvider);
+  useSettingsStore(
+    (state: SettingsStore) => state.records[0]?.tagSearchProvider,
+  );
 
 /**
  * Select settings loading state.
@@ -87,7 +92,7 @@ export const useSettingsLoading = () =>
       error: state.error,
       isLoading: state.loadingState === 'loading',
       isLoaded: state.loadingState === 'loaded',
-    }))
+    })),
   );
 
 /**
@@ -99,5 +104,5 @@ export const useSettingsActions = () =>
     useShallow((state: SettingsStore) => ({
       loadAll: state.loadAll,
       clear: state.clear,
-    }))
+    })),
   );

--- a/apps/postybirb-ui/src/stores/index.ts
+++ b/apps/postybirb-ui/src/stores/index.ts
@@ -7,22 +7,22 @@
 // =============================================================================
 
 export {
-    createEntityStore,
-    useLoadingStateSelector,
-    useRecordsSelector,
-    type BaseEntityActions,
-    type BaseEntityState,
-    type CreateEntityStoreOptions,
-    type EntityStore,
-    type LoadingState
+  createEntityStore,
+  useLoadingStateSelector,
+  useRecordsSelector,
+  type BaseEntityActions,
+  type BaseEntityState,
+  type CreateEntityStoreOptions,
+  type EntityStore,
+  type LoadingState,
 } from './create-entity-store';
 
 // Store initialization
 export {
-    areAllStoresLoaded,
-    clearAllStores,
-    loadAllStores,
-    useInitializeStores
+  areAllStoresLoaded,
+  clearAllStores,
+  loadAllStores,
+  useInitializeStores,
 } from './store-init';
 
 // =============================================================================
@@ -31,75 +31,77 @@ export {
 
 // Navigation Store
 export {
-    useCanGoBack,
-    useCanGoForward,
-    useNavigationHistory,
-    useNavigationStore,
-    useViewState,
-    useViewStateActions,
-    type NavigationStore
+  useCanGoBack,
+  useCanGoForward,
+  useNavigationHistory,
+  useNavigationStore,
+  useViewState,
+  useViewStateActions,
+  type NavigationStore,
 } from './ui/navigation-store';
 
 // Appearance Store
 export {
-    MANTINE_COLORS,
-    useAppearanceActions,
-    useAppearanceStore,
-    useColorScheme,
-    useIsCompactView,
-    usePrimaryColor,
-    useSubmissionViewMode,
-    type AppearanceStore,
-    type ColorScheme,
-    type MantinePrimaryColor,
-    type SubmissionViewMode
+  MANTINE_COLORS,
+  useAppearanceActions,
+  useAppearanceStore,
+  useColorScheme,
+  useIsCompactView,
+  usePrimaryColor,
+  useSubmissionViewMode,
+  type AppearanceStore,
+  type ColorScheme,
+  type MantinePrimaryColor,
+  type SubmissionViewMode,
 } from './ui/appearance-store';
 
 // Drawer Store
 export {
-    useActiveDrawer,
-    useDrawerActions,
-    useDrawerStore,
-    useIsDrawerOpen,
-    type DrawerKey,
-    type DrawerStore
+  useActiveDrawer,
+  useDrawerActions,
+  useDrawerStore,
+  useIsDrawerOpen,
+  type DrawerKey,
+  type DrawerStore,
 } from './ui/drawer-store';
 
 // Submissions UI Store
 export {
-    useFileSubmissionsFilter,
-    useMessageSubmissionsFilter,
-    useSidenavCollapsed, useSubmissionsContentPreferences,
-    useSubmissionsFilter,
-    useSubmissionsUIStore, useSubNavVisible, useToggleSectionPanel,
-    useToggleSidenav,
-    type SubmissionFilter,
-    type SubmissionsUIStore
+  useFileSubmissionsFilter,
+  useMessageSubmissionsFilter,
+  useSidenavCollapsed,
+  useSubmissionsContentPreferences,
+  useSubmissionsFilter,
+  useSubmissionsUIStore,
+  useSubNavVisible,
+  useToggleSectionPanel,
+  useToggleSidenav,
+  type SubmissionFilter,
+  type SubmissionsUIStore,
 } from './ui/submissions-ui-store';
 
 // Accounts UI Store
 export {
-    AccountLoginFilter,
-    useAccountsFilter,
-    useAccountsUIStore,
-    useHiddenWebsites as useUIHiddenWebsites,
-    type AccountsUIStore
+  AccountLoginFilter,
+  useAccountsFilter,
+  useAccountsUIStore,
+  useHiddenWebsites as useUIHiddenWebsites,
+  type AccountsUIStore,
 } from './ui/accounts-ui-store';
 
 // Templates UI Store
 export {
-    useTemplatesFilter,
-    useTemplatesUIStore,
-    type TemplatesUIStore
+  useTemplatesFilter,
+  useTemplatesUIStore,
+  type TemplatesUIStore,
 } from './ui/templates-ui-store';
 
 // Locale Store
 export {
-    SUPPORTED_LOCALES,
-    useLanguageActions,
-    useLocaleStore,
-    useLanguage as useUILanguage,
-    type LocaleStore
+  useLanguageActions,
+  useLocaleStore,
+  useLanguage as useUILanguage,
+  type LocaleStore,
 } from './ui/locale-store';
 
 // =============================================================================
@@ -108,102 +110,128 @@ export {
 
 // Account Store
 export {
-    groupAccountsByWebsite,
-    useAccount,
-    useAccountActions, useAccounts,
-    useAccountsLoading,
-    useAccountsMap, useAccountStore, useLoggedInAccounts,
-    type AccountStore
+  groupAccountsByWebsite,
+  useAccount,
+  useAccountActions,
+  useAccounts,
+  useAccountsLoading,
+  useAccountsMap,
+  useAccountStore,
+  useLoggedInAccounts,
+  type AccountStore,
 } from './entity/account-store';
 
 // Submission Store
 export {
-    useArchivedSubmissions,
-    useQueuedSubmissions,
-    useRegularSubmissions,
-    useScheduledSubmissions,
-    useSubmission,
-    useSubmissionActions, useSubmissions,
-    useSubmissionsByType,
-    useSubmissionsLoading,
-    useSubmissionsMap, useSubmissionStore, useSubmissionsWithErrors,
-    useTemplateSubmissions,
-    type SubmissionStore
+  useArchivedSubmissions,
+  useQueuedSubmissions,
+  useRegularSubmissions,
+  useScheduledSubmissions,
+  useSubmission,
+  useSubmissionActions,
+  useSubmissions,
+  useSubmissionsByType,
+  useSubmissionsLoading,
+  useSubmissionsMap,
+  useSubmissionStore,
+  useSubmissionsWithErrors,
+  useTemplateSubmissions,
+  type SubmissionStore,
 } from './entity/submission-store';
 
 // Custom Shortcut Store
 export {
-    customShortcutStoreRef,
-    useCustomShortcutActions, useCustomShortcuts,
-    useCustomShortcutsLoading,
-    useCustomShortcutsMap, useCustomShortcutStore, type CustomShortcutStore
+  customShortcutStoreRef,
+  useCustomShortcutActions,
+  useCustomShortcuts,
+  useCustomShortcutsLoading,
+  useCustomShortcutsMap,
+  useCustomShortcutStore,
+  type CustomShortcutStore,
 } from './entity/custom-shortcut-store';
 
 // Directory Watcher Store
 export {
-    useActiveDirectoryWatchers,
-    useDirectoryWatcherActions, useDirectoryWatchers,
-    useDirectoryWatchersLoading,
-    useDirectoryWatchersMap, useDirectoryWatcherStore, type DirectoryWatcherStore
+  useActiveDirectoryWatchers,
+  useDirectoryWatcherActions,
+  useDirectoryWatchers,
+  useDirectoryWatchersLoading,
+  useDirectoryWatchersMap,
+  useDirectoryWatcherStore,
+  type DirectoryWatcherStore,
 } from './entity/directory-watcher-store';
 
 // Notification Store
 export {
-    useErrorNotifications,
-    useNotificationActions, useNotifications,
-    useNotificationsLoading,
-    useNotificationsMap, useNotificationStore, useUnreadNotificationCount,
-    useUnreadNotifications,
-    useWarningNotifications,
-    type NotificationStore
+  useErrorNotifications,
+  useNotificationActions,
+  useNotifications,
+  useNotificationsLoading,
+  useNotificationsMap,
+  useNotificationStore,
+  useUnreadNotificationCount,
+  useUnreadNotifications,
+  useWarningNotifications,
+  type NotificationStore,
 } from './entity/notification-store';
 
 // Tag Converter Store
 export {
-    useTagConverterActions, useTagConverters,
-    useTagConvertersLoading,
-    useTagConvertersMap, useTagConverterStore, type TagConverterStore
+  useTagConverterActions,
+  useTagConverters,
+  useTagConvertersLoading,
+  useTagConvertersMap,
+  useTagConverterStore,
+  type TagConverterStore,
 } from './entity/tag-converter-store';
 
 // Tag Group Store
 export {
-    useNonEmptyTagGroups,
-    useTagGroupActions, useTagGroups,
-    useTagGroupsLoading,
-    useTagGroupsMap, useTagGroupStore, type TagGroupStore
+  useNonEmptyTagGroups,
+  useTagGroupActions,
+  useTagGroups,
+  useTagGroupsLoading,
+  useTagGroupsMap,
+  useTagGroupStore,
+  type TagGroupStore,
 } from './entity/tag-group-store';
 
 // User Converter Store
 export {
-    useUserConverterActions, useUserConverters,
-    useUserConvertersLoading,
-    useUserConvertersMap, useUserConverterStore, type UserConverterStore
+  useUserConverterActions,
+  useUserConverters,
+  useUserConvertersLoading,
+  useUserConvertersMap,
+  useUserConverterStore,
+  type UserConverterStore,
 } from './entity/user-converter-store';
 
 // Settings Store
 export {
-    useAllowAd,
-    useDesktopNotifications,
-    useHiddenWebsites,
-    useLanguage,
-    useQueuePaused,
-    useSettings,
-    useSettingsActions,
-    useSettingsLoading,
-    useSettingsOptions,
-    useSettingsStore,
-    useTagSearchProvider,
-    type SettingsStore
+  useAllowAd,
+  useDesktopNotifications,
+  useHiddenWebsites,
+  useQueuePaused,
+  useSettings,
+  useSettingsActions,
+  useSettingsLoading,
+  useSettingsOptions,
+  useSettingsStore,
+  useTagSearchProvider,
+  type SettingsStore,
 } from './entity/settings-store';
 
 // Website Store
 export {
-    useFileWebsites,
-    useMessageWebsites,
-    useWebsite,
-    useWebsiteActions, useWebsites,
-    useWebsitesLoading,
-    useWebsitesMap, useWebsiteStore, type WebsiteStore
+  useFileWebsites,
+  useMessageWebsites,
+  useWebsite,
+  useWebsiteActions,
+  useWebsites,
+  useWebsitesLoading,
+  useWebsitesMap,
+  useWebsiteStore,
+  type WebsiteStore,
 } from './entity/website-store';
 
 // =============================================================================
@@ -211,4 +239,3 @@ export {
 // =============================================================================
 
 export * from './records';
-

--- a/apps/postybirb-ui/src/stores/records/settings-record.ts
+++ b/apps/postybirb-ui/src/stores/records/settings-record.ts
@@ -3,12 +3,12 @@
  */
 
 import type {
-    DesktopNotificationSettings,
-    EntityId,
-    ISettingsOptions,
-    SettingsDto,
-    TagSearchProviderSettings,
-    WebsiteId,
+  DesktopNotificationSettings,
+  EntityId,
+  ISettingsOptions,
+  SettingsDto,
+  TagSearchProviderSettings,
+  WebsiteId,
 } from '@postybirb/types';
 import { BaseRecord } from './base-record';
 
@@ -35,11 +35,6 @@ export class SettingsRecord extends BaseRecord {
   /** List of hidden website IDs */
   get hiddenWebsites(): WebsiteId[] {
     return this.settings.hiddenWebsites;
-  }
-
-  /** Current language setting */
-  get language(): string {
-    return this.settings.language;
   }
 
   /** Whether ads are allowed */

--- a/apps/postybirb-ui/src/stores/ui/locale-store.ts
+++ b/apps/postybirb-ui/src/stores/ui/locale-store.ts
@@ -6,6 +6,11 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 import { useShallow } from 'zustand/react/shallow';
+import { supportedLocaleCodes } from '../../i18n/languages.js';
+
+type HourCycle = 'h12' | 'h24' | 'locale';
+
+type StartOfWeek = number | 'locale';
 
 // ============================================================================
 // Types
@@ -17,6 +22,18 @@ import { useShallow } from 'zustand/react/shallow';
 interface LocaleState {
   /** Current language code */
   language: string;
+
+  /**
+   * 24 hours or 12 hours (AM/PM)
+   * locale defaults to current locale info
+   */
+  hourCycle: HourCycle;
+
+  /**
+   * 0=Sunday, 1=Monday, 6=Saturday
+   * locale defaults to current locale info
+   */
+  startOfWeek: StartOfWeek;
 }
 
 /**
@@ -28,6 +45,10 @@ interface LocaleActions {
 
   /** Reset locale state */
   resetLocale: () => void;
+
+  setHourCycle: (hourCycle: HourCycle) => void;
+
+  setStartOfWeek: (startOfWeek: StartOfWeek) => void;
 }
 
 /**
@@ -44,11 +65,6 @@ export type LocaleStore = LocaleState & LocaleActions;
  */
 const STORAGE_KEY = 'postybirb-locale';
 
-/**
- * Supported locale codes for the application.
- */
-export const SUPPORTED_LOCALES = ['en', 'de', 'lt', 'pt-BR', 'ru', 'es', 'ta'];
-
 // ============================================================================
 // Helper Functions
 // ============================================================================
@@ -62,13 +78,13 @@ const getDefaultLanguage = (): string => {
     const browserLocale = navigator.language;
 
     // Check for exact match first (e.g., pt-BR)
-    if (SUPPORTED_LOCALES.includes(browserLocale)) {
+    if ((supportedLocaleCodes as string[]).includes(browserLocale)) {
       return browserLocale;
     }
 
     // Try base language (e.g., en-US -> en)
     const baseLocale = browserLocale.split('-')[0];
-    if (SUPPORTED_LOCALES.includes(baseLocale)) {
+    if ((supportedLocaleCodes as string[]).includes(baseLocale)) {
       return baseLocale;
     }
   }
@@ -84,6 +100,8 @@ const getDefaultLanguage = (): string => {
  */
 const initialState: LocaleState = {
   language: getDefaultLanguage(),
+  startOfWeek: 'locale',
+  hourCycle: 'locale',
 };
 
 // ============================================================================
@@ -101,6 +119,10 @@ export const useLocaleStore = create<LocaleStore>()(
 
       // Actions
       setLanguage: (language) => set({ language }),
+
+      setHourCycle: (hourCycle) => set({ hourCycle }),
+
+      setStartOfWeek: (startOfWeek) => set({ startOfWeek }),
 
       // Reset to initial state
       resetLocale: () => set(initialState),
@@ -125,5 +147,11 @@ export const useLanguageActions = () =>
     useShallow((state) => ({
       language: state.language,
       setLanguage: state.setLanguage,
+
+      startOfWeek: state.startOfWeek,
+      setStartOfWeek: state.setStartOfWeek,
+
+      hourCycle: state.hourCycle,
+      setHourCycle: state.setHourCycle,
     })),
   );

--- a/apps/postybirb-ui/src/stores/ui/locale-store.ts
+++ b/apps/postybirb-ui/src/stores/ui/locale-store.ts
@@ -6,7 +6,7 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 import { useShallow } from 'zustand/react/shallow';
-import { supportedLocaleCodes } from '../../i18n/languages.js';
+import { supportedLocaleCodes } from '../../i18n/languages';
 
 type HourCycle = 'h12' | 'h24' | 'locale';
 

--- a/apps/postybirb-ui/tsconfig.json
+++ b/apps/postybirb-ui/tsconfig.json
@@ -10,7 +10,7 @@
     "isolatedModules": true,
     "types": ["vite/client"],
     "noEmit": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext", "ES2025.Intl"],
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
     "esModuleInterop": false,
     "skipLibCheck": true,

--- a/apps/postybirb-ui/tsconfig.json
+++ b/apps/postybirb-ui/tsconfig.json
@@ -10,7 +10,7 @@
     "isolatedModules": true,
     "types": ["vite/client"],
     "noEmit": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "lib": ["DOM", "DOM.Iterable", "ESNext", "ES2025.Intl"],
     "allowJs": false,
     "esModuleInterop": false,
     "skipLibCheck": true,

--- a/libs/types/src/models/settings/settings-options.interface.ts
+++ b/libs/types/src/models/settings/settings-options.interface.ts
@@ -2,35 +2,25 @@ import { WebsiteId } from '../website/website.type';
 
 /**
  * Setting properties.
- * @interface
  */
 export interface ISettingsOptions {
   /**
    * Websites that should not be display in the UI.
-   * @type {string[]}
    */
   hiddenWebsites: WebsiteId[];
-  /**
-   * Language that is used by i18next
-   * @type {string}
-   */
-  language: string;
 
   /**
    * Whether to allow ad for postybirb to be added to the description.
-   * @type {boolean}
    */
   allowAd: boolean;
 
   /**
    * Whether the queue is paused by the user.
-   * @type {boolean}
    */
   queuePaused: boolean;
 
   /**
    * Desktop notification settings.
-   * @type {DesktopNotificationSettings}
    */
   desktopNotifications: DesktopNotificationSettings;
 

--- a/libs/types/src/models/settings/settings.constants.ts
+++ b/libs/types/src/models/settings/settings.constants.ts
@@ -5,7 +5,6 @@ export class SettingsConstants {
 
   static readonly DEFAULT_SETTINGS: ISettingsOptions = {
     hiddenWebsites: [],
-    language: 'en',
     allowAd: true,
     queuePaused: false,
     desktopNotifications: {

--- a/package.json
+++ b/package.json
@@ -154,7 +154,6 @@
     "megalodon": "^10.1.3",
     "mime": "^3.0.0",
     "minimist": "^1.2.8",
-    "moment": "^2.30.1",
     "multer": "^1.4.5-lts.1",
     "node-forge": "^1.3.1",
     "node-html-parser": "^7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20826,7 +20826,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"moment@npm:^2.29.1, moment@npm:^2.30.1":
+"moment@npm:^2.29.1":
   version: 2.30.1
   resolution: "moment@npm:2.30.1"
   checksum: 10c0/865e4279418c6de666fca7786607705fd0189d8a7b7624e2e56be99290ac846f90878a6f602e34b4e0455c549b85385b1baf9966845962b313699e7cb847543a
@@ -23033,7 +23033,6 @@ __metadata:
     megalodon: "npm:^10.1.3"
     mime: "npm:^3.0.0"
     minimist: "npm:^1.2.8"
-    moment: "npm:^2.30.1"
     multer: "npm:^1.4.5-lts.1"
     node-forge: "npm:^1.3.1"
     node-html-parser: "npm:^7.0.1"


### PR DESCRIPTION
1. Fully replaced momentjs with dayjs (both were installed and the latter is drop in replacement)
2. Introduced new settings (hour cycle and week start day) which default to locale values (based on Intl)
3. Improved styles for schedule calendar
4. Small style fixes across all app (language picker, template selection)

All style changes mostly related to replacing blue with the actual primary color and making external components look like mantine


| Before | After |
|--------|--------|
| <img width="1280" height="680" alt="изображение" src="https://github.com/user-attachments/assets/36647b6f-2919-4e12-9333-7a837ef173dc" />| <img width="1280" height="694" alt="изображение" src="https://github.com/user-attachments/assets/7f454333-08f9-4bc5-9cc7-3dcae7254dab" /> |
| <img width="1280" height="684" alt="изображение" src="https://github.com/user-attachments/assets/20aab791-d55f-483b-9d4d-5166e4a12467" /> | <img width="1280" height="680" alt="изображение" src="https://github.com/user-attachments/assets/12814728-4e62-45af-a869-3ab61a493e6e" /> | 

New settings:
<img width="1056" height="947" alt="изображение" src="https://github.com/user-attachments/assets/17dbf7f1-d4aa-4d02-991f-fc3d2fd4dac8" />
