### PR TITLE
Updated Dockerfile to Support ARM64 Systems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ WORKDIR /source
 COPY . .
 
 # Conditional build - only build if release/linux-unpacked doesn't exist
-RUN if [ -d "./release/linux-unpacked" ]; then \
+RUN if [ -d "./release/linux*unpacked" ]; then \
         echo "Found existing build, copying..."; \
-        cp -r ./release/linux-unpacked/ /app;\
+        cp -r ./release/linux*unpacked/ /app;\
     else \
         echo "Building from source..."; rm -rf .nx && \
         CYPRESS_INSTALL_BINARY=0 corepack yarn install --inline-builds && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:24-bookworm-slim AS builder
 
 # For ca-certificates
-RUN apt-get update && apt-get install -y curl 
+RUN apt-get update && apt-get install -y curl python[latest] build-essential
 
 WORKDIR /source
 
@@ -16,7 +16,7 @@ RUN if [ -d "./release/linux-unpacked" ]; then \
         echo "Building from source..."; rm -rf .nx && \
         CYPRESS_INSTALL_BINARY=0 corepack yarn install --inline-builds && \
         corepack yarn dist:linux --dir && \
-        cp -r ./release/linux-unpacked/ /app;\
+        cp -r ./release/linux*unpacked/ /app;\
     fi 
     
 FROM node:24-bookworm-slim


### PR DESCRIPTION
I had to make a couple of tweaks to the Dockerfile to get it to build on my ARM64 Raspberry Pi:
- Explicitly install python and build-essential at the beginning, it seems like they're not included in the ARM64 version of bookworm that docker uses as the base image
- Update the file paths to use wildcards ("./release/linux*unpacked" instead of "./release/linux-unpacked") since the ARM64 build inserts a "64" into the name of the output file

After I made those changes, it was able to finish building and I was able to deploy it from the provided docker-compose template, so everything else seems to be working!