### PR TITLE
fix(Instagram): Relax Instagram Aspect Ratio Requirements

### DIFF
--- a/apps/client-server/src/app/websites/implementations/instagram/instagram.website.ts
+++ b/apps/client-server/src/app/websites/implementations/instagram/instagram.website.ts
@@ -389,22 +389,19 @@ export default class Instagram
     const validator = this.createValidator<InstagramFileSubmission>();
 
     // Validate image aspect ratios
-    // Instagram only supports specific aspect ratios:
-    // 1:1 (square) = 1.0, 4:5 (portrait) = 0.8, 1.91:1 (landscape) = 1.91
-    const SUPPORTED_RATIOS = [
-      { name: '1:1', ratio: 1 / 1 },
-      { name: '4:5', ratio: 4 / 5 },
-      { name: '1.91:1', ratio: 1.91 / 1 },
-    ];
+    // Instagram only supports aspect ratios between 3:4 and 1.91:1
     const RATIO_TOLERANCE = 0.02; // Allow small rounding differences
+
+    const MIN_RATIO = 0.75;
+    const MAX_RATIO = 1.91;
 
     const files = postData.submission?.files ?? [];
     for (const file of files) {
       if (file.width && file.height) {
         const ratio = file.width / file.height;
-        const isSupported = SUPPORTED_RATIOS.some(
-          (sr) => Math.abs(ratio - sr.ratio) <= RATIO_TOLERANCE,
-        );
+        const isSupported =
+          ratio >= MIN_RATIO - RATIO_TOLERANCE &&
+          ratio <= MAX_RATIO + RATIO_TOLERANCE;
         if (!isSupported) {
           validator.error('validation.file.instagram.invalid-aspect-ratio', {
             fileName: file.fileName,

--- a/apps/postybirb-ui/src/i18n/validation-translation.tsx
+++ b/apps/postybirb-ui/src/i18n/validation-translation.tsx
@@ -396,8 +396,7 @@ export const TranslationMessages: TranslationsMap = {
     return (
       <Trans>
         File &quot;{fileName}&quot; has an unsupported aspect ratio for
-        Instagram. Supported ratios: 1:1 (square), 4:5 (portrait), 1.91:1
-        (landscape).
+        Instagram. Ratio must be between 3:4 and 1.91:1.
       </Trans>
     );
   },


### PR DESCRIPTION
It looks like Instagram actually supports a range of aspect ratios between 3:4 and 1.91:1, not just a static set ([source](https://help.instagram.com/1631821640426723/?helpref=uf_share)). 

I did some basic tests submitting posts (via postybirb) with nonstandard aspect ratios to Instagram, and it accepted them as long as they fell within that range. This just updates the input validation on the Instagram integration to check against a range of ratios instead of a list.