### PR TITLE
feat:Environment Variable to Override Docker Port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,10 +47,17 @@ VOLUME [ "/root/.config/postybirb" ]
 
 ENV DISPLAY=:99
 
+# Generally it's better to set the port by remapping your desired port to 8080 when running the container,
+# But this allows you to directly override the value passed to the --port argument when running Postybirb
+# (if needed)
+ENV SERVER_PORT_OVERRIDE=8080
+
+# This value can't be overridden, if you want to use the SERVER_PORT_OVERRIDE enviroment variable
+# You'll need to expose that port yourself when starting the docker container
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=5 \
-    CMD curl http://127.0.0.1:8080 || [ $? -eq 52 ] && exit 0 || exit 1
+    CMD curl http://127.0.0.1:${SERVER_PORT_OVERRIDE} || [ $? -eq 52 ] && exit 0 || exit 1
 
 COPY ./entrypoint.sh .
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
 #! /usr/bin/bash
 set -o pipefail
-xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" ./PostyBirb --headless --no-sandbox --port=8080 |& grep -v -E "ERROR:viz_main_impl\.cc\(183\)|ERROR:object_proxy\.cc\(576\)|ERROR:bus\.cc\(408\)|ERROR:browser_main_loop\.cc\(276\)|ERROR:gles2_cmd_decoder_passthrough\.cc\(1094\)|ERROR:gl_utils\.cc\(431\)"
+xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" ./PostyBirb --headless --no-sandbox --port=${SERVER_PORT_OVERRIDE} |& grep -v -E "ERROR:viz_main_impl\.cc\(183\)|ERROR:object_proxy\.cc\(576\)|ERROR:bus\.cc\(408\)|ERROR:browser_main_loop\.cc\(276\)|ERROR:gles2_cmd_decoder_passthrough\.cc\(1094\)|ERROR:gl_utils\.cc\(431\)"


### PR DESCRIPTION
This adds the environment variable `SERVER_PORT_OVERRIDE` to the docker image, which you can use to directly override the port that gets passed to Postybirb via the `--port` parameter. I've found this useful for testing and troubleshooting, particularly with OAuth redirection issues.

The environment variable still defaults to 8080, so if the environment variable isn't specified when the Docker container initializes then it should run exactly the same as it did before this change.