### PR TITLE
feat: Make Docker Use POSTYBIRB_PORT Environment Variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,10 +47,15 @@ VOLUME [ "/root/.config/postybirb" ]
 
 ENV DISPLAY=:99
 
-EXPOSE 8080
+ENV POSTYBIRB_PORT=8080
+
+# Note that this isn't dynamic, so if you use a port
+# Other than 8080 you'll need to map it when you run 
+# the docker image
+EXPOSE $POSTYBIRB_PORT
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=5 \
-    CMD curl http://127.0.0.1:8080 || [ $? -eq 52 ] && exit 0 || exit 1
+    CMD curl http://127.0.0.1:${POSTYBIRB_PORT} || [ $? -eq 52 ] && exit 0 || exit 1
 
 COPY ./entrypoint.sh .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,10 +47,17 @@ VOLUME [ "/root/.config/postybirb" ]
 
 ENV DISPLAY=:99
 
+# Generally it's better to set the port by remapping your desired port to 8080 when running the container,
+# But this allows you to directly override the value passed to the --port argument when running Postybirb
+# (if needed)
+ENV SERVER_PORT_OVERRIDE=8080
+
+# This value can't be overridden, if you want to use the SERVER_PORT_OVERRIDE enviroment variable
+# You'll need to expose that port yourself when starting the docker container
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=5 \
-    CMD curl http://127.0.0.1:8080 || [ $? -eq 52 ] && exit 0 || exit 1
+    CMD curl http://127.0.0.1:${SERVER_PORT_OVERRIDE} || [ $? -eq 52 ] && exit 0 || exit 1
 
 COPY ./entrypoint.sh .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,17 +47,10 @@ VOLUME [ "/root/.config/postybirb" ]
 
 ENV DISPLAY=:99
 
-# Generally it's better to set the port by remapping your desired port to 8080 when running the container,
-# But this allows you to directly override the value passed to the --port argument when running Postybirb
-# (if needed)
-ENV SERVER_PORT_OVERRIDE=8080
-
-# This value can't be overridden, if you want to use the SERVER_PORT_OVERRIDE enviroment variable
-# You'll need to expose that port yourself when starting the docker container
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=5 \
-    CMD curl http://127.0.0.1:${SERVER_PORT_OVERRIDE} || [ $? -eq 52 ] && exit 0 || exit 1
+    CMD curl http://127.0.0.1:8080 || [ $? -eq 52 ] && exit 0 || exit 1
 
 COPY ./entrypoint.sh .
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
 #! /usr/bin/bash
 set -o pipefail
-xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" ./PostyBirb --headless --no-sandbox --port=8080 |& grep -v -E "ERROR:viz_main_impl\.cc\(183\)|ERROR:object_proxy\.cc\(576\)|ERROR:bus\.cc\(408\)|ERROR:browser_main_loop\.cc\(276\)|ERROR:gles2_cmd_decoder_passthrough\.cc\(1094\)|ERROR:gl_utils\.cc\(431\)"
+xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" ./PostyBirb --headless --no-sandbox |& grep -v -E "ERROR:viz_main_impl\.cc\(183\)|ERROR:object_proxy\.cc\(576\)|ERROR:bus\.cc\(408\)|ERROR:browser_main_loop\.cc\(276\)|ERROR:gles2_cmd_decoder_passthrough\.cc\(1094\)|ERROR:gl_utils\.cc\(431\)"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
 #! /usr/bin/bash
 set -o pipefail
-xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" ./PostyBirb --headless --no-sandbox --port=${SERVER_PORT_OVERRIDE} |& grep -v -E "ERROR:viz_main_impl\.cc\(183\)|ERROR:object_proxy\.cc\(576\)|ERROR:bus\.cc\(408\)|ERROR:browser_main_loop\.cc\(276\)|ERROR:gles2_cmd_decoder_passthrough\.cc\(1094\)|ERROR:gl_utils\.cc\(431\)"
+xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" ./PostyBirb --headless --no-sandbox --port=8080 |& grep -v -E "ERROR:viz_main_impl\.cc\(183\)|ERROR:object_proxy\.cc\(576\)|ERROR:bus\.cc\(408\)|ERROR:browser_main_loop\.cc\(276\)|ERROR:gles2_cmd_decoder_passthrough\.cc\(1094\)|ERROR:gl_utils\.cc\(431\)"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
 #! /usr/bin/bash
 set -o pipefail
-xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" ./PostyBirb --headless --no-sandbox --port=8080 |& grep -v -E "ERROR:viz_main_impl\.cc\(183\)|ERROR:object_proxy\.cc\(576\)|ERROR:bus\.cc\(408\)|ERROR:browser_main_loop\.cc\(276\)|ERROR:gles2_cmd_decoder_passthrough\.cc\(1094\)|ERROR:gl_utils\.cc\(431\)"
+xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" ./PostyBirb --headless --no-sandbox --port=${SERVER_PORT_OVERRIDE} |& grep -v -E "ERROR:viz_main_impl\.cc\(183\)|ERROR:object_proxy\.cc\(576\)|ERROR:bus\.cc\(408\)|ERROR:browser_main_loop\.cc\(276\)|ERROR:gles2_cmd_decoder_passthrough\.cc\(1094\)|ERROR:gl_utils\.cc\(431\)"


### PR DESCRIPTION
Updates the dockerfile to use the POSTYBIRB_PORT environment variable instead of passing in the port as a command line flag in `entrypoint.sh`. This allows you to configure the port without needing to rebuild the image.

Previously, if you tried to use POSTYBIRB_PORT to set the port when running the docker image, it would get overridden by the `--port 8080` in `entrypoint.sh` and healthchecks wouldn't work.

The port still defaults to 8080, so any existing deployments should be unaffected by this change.
