### PR TITLE
fix: better support for custom description formats which use JSON

### DIFF
--- a/apps/client-server/src/app/post-parsers/models/description-node/converters/base-converter.ts
+++ b/apps/client-server/src/app/post-parsers/models/description-node/converters/base-converter.ts
@@ -4,47 +4,67 @@ import { ConversionContext } from '../description-node.base';
 import { InlineTypes, isTextNode, TipTapNode } from '../description-node.types';
 
 /**
- * Base converter for TipTap JSON → output format.
+ * Base converter for transforming TipTap JSON into a target output format.
  *
- * Converters process TipTap nodes directly (no wrapper classes).
- * Block-level nodes are dispatched to `convertBlockNode`, inline shortcut
- * atoms to `convertInlineNode`, and text nodes to `convertTextNode`.
+ * Processes TipTap nodes directly (no wrapper classes). Block-level nodes,
+ * inline shortcut atoms, and text nodes each have dedicated abstract methods
+ * that subclasses must implement.
+ *
+ * Conversion flow:
+ * - `convert()` starts conversion of a node array and calls `convertBlocks()`
+ * - Recursion uses `convertContent()` for node content and `convertChildren()` for nested blocks.
+ * - A guard prevents infinite loops when processing the default description.
  */
 export abstract class BaseConverter {
-  /** Current depth for nested block rendering */
+  /** Current nesting depth for hierarchical block formatting. */
   protected currentDepth = 0;
 
-  /** Used to prevent loop when default shortcut is insert into default section */
+  /** Prevents infinite loops when processing the default description. */
   protected processingDefaultDescription = false;
 
+  /**
+   * Converts a block-level TipTap node (e.g., paragraph, heading, list).
+   */
   abstract convertBlockNode(
     node: TipTapNode,
     context: ConversionContext,
   ): string;
 
+  /**
+   * Converts an inline shortcut atom (e.g., mention, hashtag).
+   */
   abstract convertInlineNode(
     node: TipTapNode,
     context: ConversionContext,
   ): string;
 
+  /**
+   * Converts a plain text node.
+   */
   abstract convertTextNode(
     node: TipTapNode,
     context: ConversionContext,
   ): string;
 
   /**
-   * Converts an array of top-level TipTap nodes (block nodes).
+   * Entry point for converting an array of TipTap nodes.
+   *
+   * The default implementation calls `convertBlocks()`. Subclasses may override
+   * this method if they need to produce a different output type (e.g., a JSON
+   * structure instead of a plain string).
    */
-  convertBlocks(nodes: TipTapNode[], context: ConversionContext): string {
-    const results = nodes.map((node) => this.convertBlockNode(node, context));
-    return results.join(this.getBlockSeparator());
+  convert(nodes: TipTapNode[], context: ConversionContext): string {
+    return this.convertBlocks(nodes, context);
   }
 
   /**
-   * Converts raw TipTap block data. Handles default description recursion guard.
+   * Converts an array of block nodes.
+   *
+   * Handles the special case where the input is the default description,
+   * preventing recursive reprocessing of the same content.
    */
-  convertRawBlocks(blocks: TipTapNode[], context: ConversionContext): string {
-    const isDefaultDescription = blocks === context.defaultDescription;
+  convertBlocks(nodes: TipTapNode[], context: ConversionContext): string {
+    const isDefaultDescription = nodes === context.defaultDescription;
     if (isDefaultDescription) {
       if (this.processingDefaultDescription) {
         return '';
@@ -53,7 +73,8 @@ export abstract class BaseConverter {
     }
 
     try {
-      return this.convertBlocks(blocks, context);
+      const results = nodes.map((node) => this.convertBlockNode(node, context));
+      return results.join(this.getBlockSeparator());
     } finally {
       if (isDefaultDescription) {
         this.processingDefaultDescription = false;
@@ -62,13 +83,14 @@ export abstract class BaseConverter {
   }
 
   /**
-   * Returns the separator to use between blocks.
+   * Returns the string used to separate block-level nodes in the final output.
    */
   protected abstract getBlockSeparator(): string;
 
   /**
-   * Converts the `content` array of a block node.
-   * Dispatches each child to the appropriate handler based on type.
+   * Converts the inline content of a block node.
+   *
+   * Handles text nodes, inline shortcuts, and nested blocks appropriately.
    */
   protected convertContent(
     content: TipTapNode[] | undefined,
@@ -91,7 +113,7 @@ export abstract class BaseConverter {
   }
 
   /**
-   * Converts children blocks with increased depth.
+   * Converts child blocks, maintaining proper nesting.
    */
   protected convertChildren(
     children: TipTapNode[],
@@ -111,7 +133,10 @@ export abstract class BaseConverter {
   }
 
   /**
-   * Helper to check if a shortcut should be rendered for this website.
+   * Determines whether a shortcut should be rendered for the target website.
+   *
+   * If the shortcut has an `only` restriction, the website must be listed;
+   * otherwise, the shortcut is always rendered.
    */
   protected shouldRenderShortcut(
     node: TipTapNode,
@@ -128,7 +153,11 @@ export abstract class BaseConverter {
   }
 
   /**
-   * Helper to resolve username shortcut link.
+   * Resolves a username shortcut into a URL and the final username.
+   *
+   * Applies any context-specific username conversion, then looks up the
+   * corresponding shortcut definition. Returns `undefined` if the username
+   * or the resolved URL is missing.
    */
   protected getUsernameShortcutLink(
     node: TipTapNode,

--- a/apps/client-server/src/app/post-parsers/models/description-node/converters/base-converter.ts
+++ b/apps/client-server/src/app/post-parsers/models/description-node/converters/base-converter.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { UsernameShortcut } from '@postybirb/types';
 import { ConversionContext } from '../description-node.base';
 import { InlineTypes, isTextNode, TipTapNode } from '../description-node.types';

--- a/apps/client-server/src/app/post-parsers/models/description-node/converters/bbcode-converter.ts
+++ b/apps/client-server/src/app/post-parsers/models/description-node/converters/bbcode-converter.ts
@@ -13,7 +13,7 @@ export class BBCodeConverter extends BaseConverter {
 
     if (node.type === 'defaultShortcut') {
       if (!this.shouldRenderShortcut(node, context)) return '';
-      return this.convertRawBlocks(context.defaultDescription, context);
+      return this.convertBlocks(context.defaultDescription, context);
     }
 
     // For FA: More than 5 dashes in a line are replaced with a horizontal divider.
@@ -107,7 +107,7 @@ export class BBCodeConverter extends BaseConverter {
       if (!this.shouldRenderShortcut(node, context)) return '';
       const shortcutBlocks = context.customShortcuts.get(attrs.id);
       if (shortcutBlocks) {
-        return this.convertRawBlocks(shortcutBlocks, context);
+        return this.convertBlocks(shortcutBlocks, context);
       }
       return '';
     }

--- a/apps/client-server/src/app/post-parsers/models/description-node/converters/bbcode-converter.ts
+++ b/apps/client-server/src/app/post-parsers/models/description-node/converters/bbcode-converter.ts
@@ -1,6 +1,5 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { ConversionContext } from '../description-node.base';
-import { TipTapNode } from '../description-node.types';
+import { TipTapMark, TipTapNode } from '../description-node.types';
 import { BaseConverter } from './base-converter';
 
 export class BBCodeConverter extends BaseConverter {
@@ -133,33 +132,32 @@ export class BBCodeConverter extends BaseConverter {
   }
 
   convertTextNode(node: TipTapNode, context: ConversionContext): string {
-    const textNode = node as any;
-    if (!textNode.text) return '';
+    if (!node.text) return '';
 
-    if (textNode.text === '\n' || textNode.text === '\r\n') {
+    if (node.text === '\n' || node.text === '\r\n') {
       return '\n';
     }
 
-    const marks = textNode.marks ?? [];
+    const marks = node.marks ?? [];
 
     // Check for link mark
-    const linkMark = marks.find((m: any) => m.type === 'link');
+    const linkMark = marks.find((m) => m.type === 'link');
     if (linkMark) {
       const href = linkMark.attrs?.href ?? '';
-      const link = `[url=${href}]${textNode.text}[/url]`;
+      const link = `[url=${href}]${node.text}[/url]`;
       return this.renderTextWithMarks(
         link,
-        marks.filter((m: any) => m.type !== 'link'),
+        marks.filter((m) => m.type !== 'link'),
       );
     }
 
-    return this.renderTextWithMarks(textNode.text, marks);
+    return this.renderTextWithMarks(node.text, marks);
   }
 
   /**
    * Renders text with BBCode formatting marks applied.
    */
-  private renderTextWithMarks(text: string, marks: any[]): string {
+  private renderTextWithMarks(text: string, marks: TipTapMark[]): string {
     const segments: string[] = [];
 
     for (const mark of marks) {
@@ -191,7 +189,7 @@ export class BBCodeConverter extends BaseConverter {
       .join('')}`;
 
     // Check for textStyle mark with color
-    const textStyleMark = marks.find((m: any) => m.type === 'textStyle');
+    const textStyleMark = marks.find((m) => m.type === 'textStyle');
     if (textStyleMark?.attrs?.color) {
       segmentedText = `[color=${textStyleMark.attrs.color}]${segmentedText}[/color]`;
     }

--- a/apps/client-server/src/app/post-parsers/models/description-node/converters/custom-converter.ts
+++ b/apps/client-server/src/app/post-parsers/models/description-node/converters/custom-converter.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { ConversionContext } from '../description-node.base';
 import { TipTapNode } from '../description-node.types';
 import { BaseConverter } from './base-converter';
@@ -25,31 +24,21 @@ export class CustomConverter extends BaseConverter {
     return '\n';
   }
 
-  convertBlockNode(
-    node: TipTapNode,
-    context: ConversionContext,
-  ): string {
+  convertBlockNode(node: TipTapNode, context: ConversionContext): string {
     return this.blockHandler(node, context);
   }
 
-  convertInlineNode(
-    node: TipTapNode,
-    context: ConversionContext,
-  ): string {
+  convertInlineNode(node: TipTapNode, context: ConversionContext): string {
     if (this.inlineHandler) {
       return this.inlineHandler(node, context);
     }
     return this.convertContent(node.content, context);
   }
 
-  convertTextNode(
-    node: TipTapNode,
-    context: ConversionContext,
-  ): string {
+  convertTextNode(node: TipTapNode, context: ConversionContext): string {
     if (this.textHandler) {
       return this.textHandler(node, context);
     }
-    return (node as any).text ?? '';
+    return node.text ?? '';
   }
 }
-

--- a/apps/client-server/src/app/post-parsers/models/description-node/converters/html-converter.ts
+++ b/apps/client-server/src/app/post-parsers/models/description-node/converters/html-converter.ts
@@ -1,7 +1,6 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { encode } from 'html-entities';
 import { ConversionContext } from '../description-node.base';
-import { TipTapNode } from '../description-node.types';
+import { TipTapMark, TipTapNode } from '../description-node.types';
 import { BaseConverter } from './base-converter';
 
 export class HtmlConverter extends BaseConverter {
@@ -10,8 +9,6 @@ export class HtmlConverter extends BaseConverter {
   }
 
   convertBlockNode(node: TipTapNode, context: ConversionContext): string {
-    const attrs = node.attrs ?? {};
-
     // Handle special block types
     if (node.type === 'defaultShortcut') {
       if (!this.shouldRenderShortcut(node, context)) return '';
@@ -114,36 +111,33 @@ export class HtmlConverter extends BaseConverter {
   }
 
   convertTextNode(node: TipTapNode, context: ConversionContext): string {
-    const textNode = node as any;
-    if (!textNode.text) return '';
+    if (!node.text) return '';
 
     // Handle line breaks from merged blocks
-    if (textNode.text === '\n' || textNode.text === '\r\n') {
+    if (node.text === '\n' || node.text === '\r\n') {
       return '<br>';
     }
 
-    const marks = textNode.marks ?? [];
-    const segments: string[] = [];
-    const styles: string[] = [];
+    const marks = node.marks ?? [];
 
     // Check for link mark — wrap entire text in <a>
-    const linkMark = marks.find((m: any) => m.type === 'link');
+    const linkMark = marks.find((m) => m.type === 'link');
     if (linkMark) {
       const href = linkMark.attrs?.href ?? '';
       const innerHtml = this.renderTextWithMarks(
-        textNode.text,
-        marks.filter((m: any) => m.type !== 'link'),
+        node.text,
+        marks.filter((m) => m.type !== 'link'),
       );
       return `<a target="_blank" href="${href}">${innerHtml}</a>`;
     }
 
-    return this.renderTextWithMarks(textNode.text, marks);
+    return this.renderTextWithMarks(node.text, marks);
   }
 
   /**
    * Renders text with formatting marks (bold, italic, etc.) applied.
    */
-  private renderTextWithMarks(text: string, marks: any[]): string {
+  private renderTextWithMarks(text: string, marks: TipTapMark[]): string {
     const segments: string[] = [];
     const styles: string[] = [];
 
@@ -167,7 +161,7 @@ export class HtmlConverter extends BaseConverter {
     }
 
     // Check for textStyle mark with color
-    const textStyleMark = marks.find((m: any) => m.type === 'textStyle');
+    const textStyleMark = marks.find((m) => m.type === 'textStyle');
     if (textStyleMark?.attrs?.color) {
       styles.push(`color: ${textStyleMark.attrs.color}`);
     }

--- a/apps/client-server/src/app/post-parsers/models/description-node/converters/html-converter.ts
+++ b/apps/client-server/src/app/post-parsers/models/description-node/converters/html-converter.ts
@@ -9,16 +9,13 @@ export class HtmlConverter extends BaseConverter {
     return '';
   }
 
-  convertBlockNode(
-    node: TipTapNode,
-    context: ConversionContext,
-  ): string {
+  convertBlockNode(node: TipTapNode, context: ConversionContext): string {
     const attrs = node.attrs ?? {};
 
     // Handle special block types
     if (node.type === 'defaultShortcut') {
       if (!this.shouldRenderShortcut(node, context)) return '';
-      return this.convertRawBlocks(context.defaultDescription, context);
+      return this.convertBlocks(context.defaultDescription, context);
     }
 
     if (node.type === 'horizontalRule') return '<hr>';
@@ -68,10 +65,7 @@ export class HtmlConverter extends BaseConverter {
     return `<${tag}${styles ? ` style="${styles}"` : ''}>${content}</${tag}>`;
   }
 
-  convertInlineNode(
-    node: TipTapNode,
-    context: ConversionContext,
-  ): string {
+  convertInlineNode(node: TipTapNode, context: ConversionContext): string {
     const attrs = node.attrs ?? {};
 
     if (node.type === 'username') {
@@ -86,7 +80,7 @@ export class HtmlConverter extends BaseConverter {
       if (!this.shouldRenderShortcut(node, context)) return '';
       const shortcutBlocks = context.customShortcuts.get(attrs.id);
       if (shortcutBlocks) {
-        return this.convertRawBlocks(shortcutBlocks, context);
+        return this.convertBlocks(shortcutBlocks, context);
       }
       return '';
     }
@@ -119,10 +113,7 @@ export class HtmlConverter extends BaseConverter {
     return content ? `<span>${content}</span>` : '';
   }
 
-  convertTextNode(
-    node: TipTapNode,
-    context: ConversionContext,
-  ): string {
+  convertTextNode(node: TipTapNode, context: ConversionContext): string {
     const textNode = node as any;
     if (!textNode.text) return '';
 
@@ -139,7 +130,10 @@ export class HtmlConverter extends BaseConverter {
     const linkMark = marks.find((m: any) => m.type === 'link');
     if (linkMark) {
       const href = linkMark.attrs?.href ?? '';
-      const innerHtml = this.renderTextWithMarks(textNode.text, marks.filter((m: any) => m.type !== 'link'));
+      const innerHtml = this.renderTextWithMarks(
+        textNode.text,
+        marks.filter((m: any) => m.type !== 'link'),
+      );
       return `<a target="_blank" href="${href}">${innerHtml}</a>`;
     }
 
@@ -178,7 +172,10 @@ export class HtmlConverter extends BaseConverter {
       styles.push(`color: ${textStyleMark.attrs.color}`);
     }
 
-    const encodedText = encode(text, { level: 'html5' }).replace(/\n/g, '<br />');
+    const encodedText = encode(text, { level: 'html5' }).replace(
+      /\n/g,
+      '<br />',
+    );
 
     if (!segments.length && !styles.length) {
       return encodedText;
@@ -204,10 +201,7 @@ export class HtmlConverter extends BaseConverter {
     const attrs = node.attrs ?? {};
     const styles: string[] = [];
 
-    if (
-      attrs.textAlign &&
-      attrs.textAlign !== 'left'
-    ) {
+    if (attrs.textAlign && attrs.textAlign !== 'left') {
       styles.push(`text-align: ${attrs.textAlign}`);
     }
 
@@ -233,4 +227,3 @@ export class HtmlConverter extends BaseConverter {
     return `<div>${imgTag}</div>`;
   }
 }
-

--- a/apps/client-server/src/app/post-parsers/models/description-node/converters/npf-converter.spec.ts
+++ b/apps/client-server/src/app/post-parsers/models/description-node/converters/npf-converter.spec.ts
@@ -266,7 +266,7 @@ describe('NpfConverter', () => {
         },
       ];
 
-      const resultJson = converter.convertBlocks(nodes, context);
+      const resultJson = converter.convert(nodes, context);
       const result = JSON.parse(resultJson) as NPFTextBlock;
 
       expect(result).toMatchInlineSnapshot(`

--- a/apps/client-server/src/app/post-parsers/models/description-node/converters/npf-converter.ts
+++ b/apps/client-server/src/app/post-parsers/models/description-node/converters/npf-converter.ts
@@ -27,7 +27,7 @@ export class NpfConverter extends BaseConverter {
   /**
    * Override convertBlocks to accumulate NPF blocks and return JSON.
    */
-  convertBlocks(nodes: TipTapNode[], context: ConversionContext): string {
+  convert(nodes: TipTapNode[], context: ConversionContext): string {
     this.blocks = [];
     for (const node of nodes) {
       this.convertBlockNodeRecursive(node, context, 0);

--- a/apps/client-server/src/app/post-parsers/models/description-node/converters/npf-converter.ts
+++ b/apps/client-server/src/app/post-parsers/models/description-node/converters/npf-converter.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   NPFContentBlock,
   NPFImageBlock,
@@ -25,7 +24,7 @@ export class NpfConverter extends BaseConverter {
   }
 
   /**
-   * Override convertBlocks to accumulate NPF blocks and return JSON.
+   * Override convert to accumulate NPF blocks and return JSON.
    */
   convert(nodes: TipTapNode[], context: ConversionContext): string {
     this.blocks = [];

--- a/apps/client-server/src/app/post-parsers/models/description-node/converters/plaintext-converter.ts
+++ b/apps/client-server/src/app/post-parsers/models/description-node/converters/plaintext-converter.ts
@@ -11,7 +11,7 @@ export class PlainTextConverter extends BaseConverter {
   convertBlockNode(node: TipTapNode, context: ConversionContext): string {
     if (node.type === 'defaultShortcut') {
       if (!this.shouldRenderShortcut(node, context)) return '';
-      return this.convertRawBlocks(context.defaultDescription, context);
+      return this.convertBlocks(context.defaultDescription, context);
     }
 
     if (node.type === 'horizontalRule') return '----------';
@@ -73,7 +73,7 @@ export class PlainTextConverter extends BaseConverter {
       if (!this.shouldRenderShortcut(node, context)) return '';
       const shortcutBlocks = context.customShortcuts.get(attrs.id);
       if (shortcutBlocks) {
-        return this.convertRawBlocks(shortcutBlocks, context);
+        return this.convertBlocks(shortcutBlocks, context);
       }
       return '';
     }

--- a/apps/client-server/src/app/post-parsers/models/description-node/converters/plaintext-converter.ts
+++ b/apps/client-server/src/app/post-parsers/models/description-node/converters/plaintext-converter.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { ConversionContext } from '../description-node.base';
 import { TipTapNode } from '../description-node.types';
 import { BaseConverter } from './base-converter';
@@ -99,18 +98,16 @@ export class PlainTextConverter extends BaseConverter {
   }
 
   convertTextNode(node: TipTapNode, context: ConversionContext): string {
-    const textNode = node as any;
-
     // Check for link mark — append URL
-    const marks = textNode.marks ?? [];
-    const linkMark = marks.find((m: any) => m.type === 'link');
+    const marks = node.marks ?? [];
+    const linkMark = marks.find((m) => m.type === 'link');
     if (linkMark) {
       const href = linkMark.attrs?.href ?? '';
-      if (textNode.text === href) return href;
+      if (node.text === href) return href;
 
-      return `${textNode.text}: ${href}`;
+      return `${node.text}: ${href}`;
     }
 
-    return textNode.text ?? '';
+    return node.text ?? '';
   }
 }

--- a/apps/client-server/src/app/post-parsers/models/description-node/description-node-tree.ts
+++ b/apps/client-server/src/app/post-parsers/models/description-node/description-node-tree.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import TurndownService from 'turndown';
 import { BaseConverter } from './converters/base-converter';
 import { BBCodeConverter } from './converters/bbcode-converter';
@@ -170,9 +169,7 @@ export class DescriptionNodeTree {
     }
 
     return node.content.every(
-      (child) =>
-        child.type === 'text' &&
-        (!(child as any).text || (child as any).text.trim() === ''),
+      (child) => child.type === 'text' && !child.text?.trim(),
     );
   }
 

--- a/apps/client-server/src/app/post-parsers/models/description-node/description-node-tree.ts
+++ b/apps/client-server/src/app/post-parsers/models/description-node/description-node-tree.ts
@@ -59,17 +59,17 @@ export class DescriptionNodeTree {
 
   toBBCode(): string {
     const converter = new BBCodeConverter();
-    return converter.convertBlocks(this.withInsertions(), this.context);
+    return converter.convert(this.withInsertions(), this.context);
   }
 
   toPlainText(): string {
     const converter = new PlainTextConverter();
-    return converter.convertBlocks(this.withInsertions(), this.context);
+    return converter.convert(this.withInsertions(), this.context);
   }
 
   toHtml(): string {
     const converter = new HtmlConverter();
-    return converter.convertBlocks(this.withInsertions(), this.context);
+    return converter.convert(this.withInsertions(), this.context);
   }
 
   toMarkdown(turndownService?: TurndownService): string {
@@ -89,11 +89,11 @@ export class DescriptionNodeTree {
 
   parseCustom(blockHandler: CustomNodeHandler): string {
     const converter = new CustomConverter(blockHandler);
-    return converter.convertBlocks(this.withInsertions(), this.context);
+    return converter.convert(this.withInsertions(), this.context);
   }
 
   parseWithConverter(converter: BaseConverter): string {
-    return converter.convertBlocks(this.withInsertions(), this.context);
+    return converter.convert(this.withInsertions(), this.context);
   }
 
   public updateContext(updates: Partial<ConversionContext>): void {

--- a/apps/client-server/src/app/post-parsers/models/description-node/description-node.base.ts
+++ b/apps/client-server/src/app/post-parsers/models/description-node/description-node.base.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { UsernameShortcut } from '@postybirb/types';
 import { TipTapNode } from './description-node.types';
 

--- a/apps/client-server/src/app/websites/implementations/bluesky/bluesky.website.ts
+++ b/apps/client-server/src/app/websites/implementations/bluesky/bluesky.website.ts
@@ -794,14 +794,9 @@ class BlueskyConverter extends PlainTextConverter {
     return super.convertTextNode(node, context);
   }
 
-  convertBlocks(nodes: TipTapNode[], context: ConversionContext): string {
-    // When plaintext encouters the default description it uses convertRawBlocks which calls convertBlock
-    // which returns json that ends up in user posts
-    if (nodes === context.defaultDescription)
-      return super.convertBlocks(nodes, context);
-
+  convert(nodes: TipTapNode[], context: ConversionContext): string {
     this.links = [];
-    let text = super.convertBlocks(nodes, context);
+    let text = super.convert(nodes, context);
 
     const newLinks: RichTextLinkPosition[] = [];
 

--- a/apps/client-server/src/app/websites/implementations/e621/e621.website.ts
+++ b/apps/client-server/src/app/websites/implementations/e621/e621.website.ts
@@ -375,8 +375,8 @@ class E621Converter extends BBCodeConverter {
     return super.convertBlockNode(node, context);
   }
 
-  convertBlocks(nodes: TipTapNode[], context: ConversionContext): string {
-    const text = super.convertBlocks(nodes, context);
+  convert(nodes: TipTapNode[], context: ConversionContext): string {
+    const text = super.convert(nodes, context);
 
     return text
       .replace(/\[url=([^\]]*)\]([^[]*)\[\/url\]/g, '"$2":[$1]')

--- a/apps/client-server/src/app/websites/implementations/telegram/telegram.website.ts
+++ b/apps/client-server/src/app/websites/implementations/telegram/telegram.website.ts
@@ -568,13 +568,8 @@ class TelegramConverter extends HtmlConverter {
     return '<br>';
   }
 
-  convertBlocks(nodes: TipTapNode[], context: ConversionContext): string {
-    // When html encouters the default description it uses convertRawBlocks which calls convertBlock
-    // which returns json that ends up in user posts
-    if (nodes === context.defaultDescription)
-      return super.convertBlocks(nodes, context);
-
-    let html = super.convertBlocks(nodes, context);
+  convert(nodes: TipTapNode[], context: ConversionContext): string {
+    let html = super.convert(nodes, context);
 
     html = html.replaceAll('<hr>', '<span>————————</span>');
 


### PR DESCRIPTION
#761 

1. Improved documentation on base converter to better align with what it actually does
2. Replaces convertRawBlocks with convertBlocks and moves inifnity loop catch into it (safer)
3. Adds convert method which is a single entrypoint used by websites like telegram, bluesky, e621 and tumblr instead of internal convertBlocks that was previously also called for custom shortcuts and default descriptions resulting in bugs like #761
4. Replaces 'any' with actual types