### PR TITLE
fix: mastodon login view

### DIFF
--- a/apps/postybirb-ui/src/components/website-login-views/megalodon/megalodon-login-view.tsx
+++ b/apps/postybirb-ui/src/components/website-login-views/megalodon/megalodon-login-view.tsx
@@ -2,6 +2,8 @@ import { Trans } from '@lingui/react/macro';
 import {
   Alert,
   Button,
+  Group,
+  Loader,
   Paper,
   Stack,
   Stepper,
@@ -12,6 +14,7 @@ import {
 import { MegalodonAccountData, MegalodonOAuthRoutes } from '@postybirb/types';
 import { IconCheck, IconExternalLink, IconServer } from '@tabler/icons-react';
 import { useState } from 'react';
+import accountApi from '../../../api/account.api';
 import websitesApi from '../../../api/websites.api';
 import { showSuccessNotification } from '../../../utils';
 import { ExternalLink } from '../../shared/external-link';
@@ -47,6 +50,45 @@ export default function MegalodonLoginView(
     setLoggedInAs(undefined);
     setActiveStep(0);
   };
+
+  const handleTryAgain = () => {
+    accountApi.refreshLogin(account.id);
+  };
+
+  if (loggedInAs && !account.isLoggedIn) {
+    return (
+      <LoginViewContainer>
+        <Stack>
+          <Title order={3}>
+            <Trans>Fediverse Authentication</Trans>
+          </Title>
+
+          <Alert color="red">
+            <Stack>
+              <Trans>
+                Login was not successfull, tried to login as {loggedInAs}
+              </Trans>
+              <Button
+                variant="destructive"
+                onClick={handleTryAgain}
+                disabled={account.isPending}
+              >
+                <Group>
+                  <Trans>Try again</Trans>
+                  {account.isPending && <Loader size="xs" />}
+                </Group>
+              </Button>
+              <Button onClick={handleStartOver}>
+                <Trans>
+                  Reset data and start again or log in to different instance
+                </Trans>
+              </Button>
+            </Stack>
+          </Alert>
+        </Stack>
+      </LoginViewContainer>
+    );
+  }
 
   return (
     <LoginViewContainer>

--- a/apps/postybirb-ui/src/components/website-login-views/misskey/misskey-login-view.tsx
+++ b/apps/postybirb-ui/src/components/website-login-views/misskey/misskey-login-view.tsx
@@ -1,17 +1,20 @@
 import { Trans } from '@lingui/react/macro';
 import {
-    Alert,
-    Button,
-    Paper,
-    Stack,
-    Stepper,
-    Text,
-    TextInput,
-    Title,
+  Alert,
+  Button,
+  Group,
+  Loader,
+  Paper,
+  Stack,
+  Stepper,
+  Text,
+  TextInput,
+  Title,
 } from '@mantine/core';
 import { MisskeyAccountData, MisskeyOAuthRoutes } from '@postybirb/types';
 import { IconCheck, IconExternalLink, IconServer } from '@tabler/icons-react';
 import { useState } from 'react';
+import accountApi from '../../../api/account.api';
 import websitesApi from '../../../api/websites.api';
 import { showSuccessNotification } from '../../../utils';
 import { ExternalLink } from '../../shared/external-link';
@@ -42,6 +45,45 @@ export default function MisskeyLoginView(
     setLoggedInAs(undefined);
     setActiveStep(0);
   };
+
+  const handleTryAgain = () => {
+    accountApi.refreshLogin(account.id);
+  };
+
+  if (loggedInAs && !account.isLoggedIn) {
+    return (
+      <LoginViewContainer>
+        <Stack>
+          <Title order={3}>
+            <Trans>Misskey Authentication</Trans>
+          </Title>
+
+          <Alert color="red">
+            <Stack>
+              <Trans>
+                Login was not successfull, tried to login as {loggedInAs}
+              </Trans>
+              <Button
+                variant="destructive"
+                onClick={handleTryAgain}
+                disabled={account.isPending}
+              >
+                <Group>
+                  <Trans>Try again</Trans>
+                  {account.isPending && <Loader size="xs" />}
+                </Group>
+              </Button>
+              <Button onClick={handleStartOver}>
+                <Trans>
+                  Reset data and start again or log in to different instance
+                </Trans>
+              </Button>
+            </Stack>
+          </Alert>
+        </Stack>
+      </LoginViewContainer>
+    );
+  }
 
   return (
     <LoginViewContainer>
@@ -78,8 +120,9 @@ export default function MisskeyLoginView(
                   <Text size="sm">
                     <Trans>
                       Enter the URL of your Misskey instance (e.g.,
-                      &quot;misskey.io&quot; or &quot;sharkey.example.com&quot;).
-                      Works with Misskey and compatible forks.
+                      &quot;misskey.io&quot; or
+                      &quot;sharkey.example.com&quot;). Works with Misskey and
+                      compatible forks.
                     </Trans>
                   </Text>
                 </Alert>
@@ -101,10 +144,11 @@ export default function MisskeyLoginView(
                       .replace(/^https?:\/\//, '')
                       .replace(/\/$/, '');
                     websitesApi
-                      .performOAuthStep<
-                        MisskeyOAuthRoutes,
-                        'generateAuthUrl'
-                      >(id, 'generateAuthUrl', { instanceUrl: cleanedUrl })
+                      .performOAuthStep<MisskeyOAuthRoutes, 'generateAuthUrl'>(
+                        id,
+                        'generateAuthUrl',
+                        { instanceUrl: cleanedUrl },
+                      )
                       .then((res) => {
                         if (res.success && res.authUrl) {
                           setAuthUrl(res.authUrl);
@@ -132,9 +176,7 @@ export default function MisskeyLoginView(
 
           <Stepper.Step
             label={<Trans>Authorize</Trans>}
-            description={
-              <Trans>Authorize PostyBirb on your instance</Trans>
-            }
+            description={<Trans>Authorize PostyBirb on your instance</Trans>}
             icon={<IconExternalLink size={16} />}
           >
             <Paper p="md" withBorder>


### PR DESCRIPTION
Fixes issue where successfull login becomes obsolete but the ui still displays as if it were successfull resulting in confusion in users (i can't really find the report on discord this time)