### PR TITLE
fix(ui): restrict drag to grip handle and add Alt+Arrow reordering for file cards

### DIFF
--- a/apps/postybirb-ui/src/components/sections/submissions-section/submission-edit-card/file-management/submission-file-card.tsx
+++ b/apps/postybirb-ui/src/components/sections/submissions-section/submission-edit-card/file-management/submission-file-card.tsx
@@ -4,28 +4,25 @@
 
 import { Trans } from '@lingui/react/macro';
 import {
-    ActionIcon,
-    Badge,
-    Box,
-    Collapse,
-    Divider,
-    Flex,
-    Group,
-    Paper,
-    Text,
-    Tooltip,
+  ActionIcon,
+  Badge,
+  Box,
+  Collapse,
+  Divider,
+  Flex,
+  Group,
+  Paper,
+  Text,
+  Tooltip,
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
-import {
-    FileType,
-    ISubmissionFileDto,
-} from '@postybirb/types';
+import { FileType, ISubmissionFileDto } from '@postybirb/types';
 import { getFileType } from '@postybirb/utils/file-type';
 import {
-    IconChevronDown,
-    IconGripVertical,
-    IconPencil,
-    IconTrash
+  IconChevronDown,
+  IconGripVertical,
+  IconPencil,
+  IconTrash,
 } from '@tabler/icons-react';
 import { memo } from 'react';
 import fileSubmissionApi from '../../../../../api/file-submission.api';
@@ -40,144 +37,157 @@ interface SubmissionFileCardProps {
   file: ISubmissionFileDto;
   draggable: boolean;
   totalFiles: number;
+  dragListeners?: Record<string, unknown>;
 }
 
-export const SubmissionFileCard = memo(({
-  file,
-  draggable,
-  totalFiles,
-}: SubmissionFileCardProps) => {
-  const { submission } = useSubmissionEditCardContext();
-  const accounts = useSubmissionAccounts();
-  const [expanded, { toggle }] = useDisclosure(false);
-  const fileType = getFileType(file.fileName);
+export const SubmissionFileCard = memo(
+  ({ file, draggable, totalFiles, dragListeners }: SubmissionFileCardProps) => {
+    const { submission } = useSubmissionEditCardContext();
+    const accounts = useSubmissionAccounts();
+    const [expanded, { toggle }] = useDisclosure(false);
+    const fileType = getFileType(file.fileName);
 
-  const canDelete = totalFiles > 1 && !submission.isArchived;
+    const canDelete = totalFiles > 1 && !submission.isArchived;
 
-  const handleDelete = async () => {
-    if (!canDelete) return;
+    const handleDelete = async () => {
+      if (!canDelete) return;
 
-    try {
-      await fileSubmissionApi.removeFile(submission.id, file.id, 'file');
-    } catch (error) {
-      showErrorWithContext(error, <Trans>Failed to delete file</Trans>);
-    }
-  };
+      try {
+        await fileSubmissionApi.removeFile(submission.id, file.id, 'file');
+      } catch (error) {
+        showErrorWithContext(error, <Trans>Failed to delete file</Trans>);
+      }
+    };
 
-  return (
-    <Paper
-      p="sm"
-      shadow="xs"
-      radius="md"
-      withBorder
-      className={DRAGGABLE_FILE_CLASS}
-      style={{
-        cursor: draggable ? 'grab' : undefined,
-        position: 'relative',
-      }}
-    >
-      {/* Drag handle */}
-      {draggable && (
-        <Box
-          style={{
-            position: 'absolute',
-            left: 8,
-            top: '50%',
-            transform: 'translateY(-50%)',
-            opacity: 0.5,
-            cursor: 'grab',
-          }}
-        >
-          <IconGripVertical size={16} />
-        </Box>
-      )}
+    return (
+      <Paper
+        p="sm"
+        shadow="xs"
+        radius="md"
+        withBorder
+        className={DRAGGABLE_FILE_CLASS}
+        style={{
+          position: 'relative',
+        }}
+      >
+        {/* Drag handle */}
+        {draggable && (
+          <Box
+            {...dragListeners}
+            style={{
+              position: 'absolute',
+              left: 8,
+              top: '50%',
+              transform: 'translateY(-50%)',
+              opacity: 0.5,
+              cursor: 'grab',
+            }}
+          >
+            <IconGripVertical size={16} />
+          </Box>
+        )}
 
-      <Flex gap="md" align="flex-start" ml={draggable ? 'md' : 0}>
-        {/* File Preview with Actions */}
-        <Box
-          style={{
-            // eslint-disable-next-line lingui/no-unlocalized-strings
-            flex: '0 0 auto',
-            padding: 4,
-            borderRadius: 8,
-          }}
-        >
-          <FileActions file={file} submissionId={submission.id} />
-        </Box>
+        <Flex gap="md" align="flex-start" ml={draggable ? 'md' : 0}>
+          {/* File Preview with Actions */}
+          <Box
+            style={{
+              // eslint-disable-next-line lingui/no-unlocalized-strings
+              flex: '0 0 auto',
+              padding: 4,
+              borderRadius: 8,
+            }}
+          >
+            <FileActions file={file} submissionId={submission.id} />
+          </Box>
 
-        {/* File Info */}
-        <Box style={{ flex: 1, minWidth: 0 }}>
-          <Group justify="space-between" wrap="nowrap" mb={4}>
-            <Group gap="xs" wrap="nowrap" style={{ minWidth: 0 }}>
-              <Text size="sm" fw={600} truncate style={{ maxWidth: 200 }}>
-                {file.fileName}
-              </Text>
-              <Badge
-                size="xs"
-                variant="light"
-                color={getFileTypeColor(fileType)}
-              >
-                {fileType}
-              </Badge>
-            </Group>
+          {/* File Info */}
+          <Box style={{ flex: 1, minWidth: 0 }}>
+            <Group justify="space-between" wrap="nowrap" mb={4}>
+              <Group gap="xs" wrap="nowrap" style={{ minWidth: 0 }}>
+                <Text
+                  size="sm"
+                  fw={600}
+                  truncate
+                  style={{ maxWidth: 200 }}
+                  title={file.fileName}
+                >
+                  {file.fileName}
+                </Text>
+                <Badge
+                  size="xs"
+                  variant="light"
+                  color={getFileTypeColor(fileType)}
+                >
+                  {fileType}
+                </Badge>
+              </Group>
 
-            <Group gap="xs">
-              {/* Edit metadata button - more discoverable */}
-              {!submission.isArchived && (
-                <Tooltip label={expanded ? <Trans>Collapse</Trans> : <Trans>Edit metadata</Trans>}>
-                  <ActionIcon 
-                    size="sm" 
-                    variant={expanded ? "filled" : "light"}
-                    color="blue"
-                    onClick={toggle}
+              <Group gap="xs">
+                {/* Edit metadata button - more discoverable */}
+                {!submission.isArchived && (
+                  <Tooltip
+                    label={
+                      expanded ? (
+                        <Trans>Collapse</Trans>
+                      ) : (
+                        <Trans>Edit metadata</Trans>
+                      )
+                    }
                   >
-                    {expanded ? (
-                      <IconChevronDown size={14} />
+                    <ActionIcon
+                      size="sm"
+                      variant={expanded ? 'filled' : 'light'}
+                      color="blue"
+                      onClick={toggle}
+                    >
+                      {expanded ? (
+                        <IconChevronDown size={14} />
+                      ) : (
+                        <IconPencil size={14} />
+                      )}
+                    </ActionIcon>
+                  </Tooltip>
+                )}
+
+                {/* Delete button */}
+                <Tooltip
+                  label={
+                    canDelete ? (
+                      <Trans>Delete file</Trans>
                     ) : (
-                      <IconPencil size={14} />
-                    )}
+                      <Trans>Cannot delete the only file</Trans>
+                    )
+                  }
+                >
+                  <ActionIcon
+                    size="sm"
+                    variant="subtle"
+                    color="red"
+                    disabled={!canDelete}
+                    onClick={handleDelete}
+                  >
+                    <IconTrash size={14} />
                   </ActionIcon>
                 </Tooltip>
-              )}
-
-              {/* Delete button */}
-              <Tooltip
-                label={
-                  canDelete ? (
-                    <Trans>Delete file</Trans>
-                  ) : (
-                    <Trans>Cannot delete the only file</Trans>
-                  )
-                }
-              >
-                <ActionIcon
-                  size="sm"
-                  variant="subtle"
-                  color="red"
-                  disabled={!canDelete}
-                  onClick={handleDelete}
-                >
-                  <IconTrash size={14} />
-                </ActionIcon>
-              </Tooltip>
+              </Group>
             </Group>
-          </Group>
 
-          {/* File size */}
-          <Text size="xs" c="dimmed">
-            {formatFileSize(file.size)} • {file.width}×{file.height}
-          </Text>
-        </Box>
-      </Flex>
+            {/* File size */}
+            <Text size="xs" c="dimmed">
+              {formatFileSize(file.size)} • {file.width}×{file.height}
+            </Text>
+          </Box>
+        </Flex>
 
-      {/* Expandable metadata section */}
-      <Collapse in={expanded} ml="lg">
-        <Divider my="sm" variant="dashed" />
-        <FileMetadata file={file} accounts={accounts} />
-      </Collapse>
-    </Paper>
-  );
-});
+        {/* Expandable metadata section */}
+        <Collapse in={expanded} ml="lg">
+          <Divider my="sm" variant="dashed" />
+          <FileMetadata file={file} accounts={accounts} />
+        </Collapse>
+      </Paper>
+    );
+  },
+);
 
 function getFileTypeColor(fileType: FileType): string {
   switch (fileType) {

--- a/apps/postybirb-ui/src/components/sections/submissions-section/submission-edit-card/file-management/submission-file-manager.tsx
+++ b/apps/postybirb-ui/src/components/sections/submissions-section/submission-edit-card/file-management/submission-file-manager.tsx
@@ -66,10 +66,14 @@ function SortableFileCard({
   file,
   isDraggable,
   totalFiles,
+  onMoveUp,
+  onMoveDown,
 }: {
   file: ISubmissionFileDto;
   isDraggable: boolean;
   totalFiles: number;
+  onMoveUp: (id: string) => void;
+  onMoveDown: (id: string) => void;
 }) {
   const {
     attributes,
@@ -89,12 +93,33 @@ function SortableFileCard({
     opacity: isDragging ? 0.5 : 1,
   };
 
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!isDraggable || !e.altKey) return;
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        onMoveUp(file.id);
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        onMoveDown(file.id);
+      }
+    },
+    [isDraggable, file.id, onMoveUp, onMoveDown],
+  );
+
   return (
-    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      onKeyDown={handleKeyDown}
+    >
       <SubmissionFileCard
         file={file}
         draggable={isDraggable}
         totalFiles={totalFiles}
+        dragListeners={isDraggable ? listeners : undefined}
       />
     </div>
   );
@@ -128,6 +153,28 @@ export function SubmissionFileManager() {
     [orderedFiles],
   );
 
+  const applyReorder = useCallback(
+    (oldIndex: number, newIndex: number) => {
+      const newOrderedFiles = arrayMove(orderedFiles, oldIndex, newIndex);
+
+      const baseOrder = Date.now();
+      newOrderedFiles.forEach((file, index) => {
+        // eslint-disable-next-line no-param-reassign
+        file.order = baseOrder + index;
+      });
+
+      setOrderedFiles(newOrderedFiles);
+
+      fileSubmissionApi.reorder({
+        order: newOrderedFiles.reduce((acc: Record<string, number>, file) => {
+          acc[file.id] = file.order ?? 0;
+          return acc;
+        }, {}),
+      });
+    },
+    [orderedFiles],
+  );
+
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
       const { active, over } = event;
@@ -137,26 +184,25 @@ export function SubmissionFileManager() {
       const newIndex = orderedFiles.findIndex((f) => f.id === over.id);
       if (oldIndex === -1 || newIndex === -1) return;
 
-      const newOrderedFiles = arrayMove(orderedFiles, oldIndex, newIndex);
-
-      // Update order property for all files
-      const baseOrder = Date.now();
-      newOrderedFiles.forEach((file, index) => {
-        // eslint-disable-next-line no-param-reassign
-        file.order = baseOrder + index;
-      });
-
-      setOrderedFiles(newOrderedFiles);
-
-      // Persist to backend
-      fileSubmissionApi.reorder({
-        order: newOrderedFiles.reduce((acc: Record<string, number>, file) => {
-          acc[file.id] = file.order ?? 0;
-          return acc;
-        }, {}),
-      });
+      applyReorder(oldIndex, newIndex);
     },
-    [orderedFiles],
+    [orderedFiles, applyReorder],
+  );
+
+  const handleMoveUp = useCallback(
+    (id: string) => {
+      const index = orderedFiles.findIndex((f) => f.id === id);
+      if (index > 0) applyReorder(index, index - 1);
+    },
+    [orderedFiles, applyReorder],
+  );
+
+  const handleMoveDown = useCallback(
+    (id: string) => {
+      const index = orderedFiles.findIndex((f) => f.id === id);
+      if (index < orderedFiles.length - 1) applyReorder(index, index + 1);
+    },
+    [orderedFiles, applyReorder],
   );
 
   const isDraggable = orderedFiles.length > 1 && !submission.isArchived;
@@ -222,6 +268,8 @@ export function SubmissionFileManager() {
                   file={file}
                   isDraggable={isDraggable}
                   totalFiles={orderedFiles.length}
+                  onMoveUp={handleMoveUp}
+                  onMoveDown={handleMoveDown}
                 />
               ))}
             </Stack>


### PR DESCRIPTION
Drag listeners are now scoped to the grip icon only, allowing text selection on the rest of the card. File cards can also be reordered with Alt+ArrowUp/Down when focused.