### PR TITLE
fix(ui): history view updates live and running posts no longer show as failed

### DIFF
--- a/apps/postybirb-ui/src/components/sections/submissions-section/submission-history/history-utils.ts
+++ b/apps/postybirb-ui/src/components/sections/submissions-section/submission-history/history-utils.ts
@@ -3,13 +3,26 @@
  */
 
 import {
-    EntityId,
-    PostEventDto,
-    PostEventType,
-    PostRecordDto,
-    PostRecordState,
+  EntityId,
+  PostEventDto,
+  PostEventType,
+  PostRecordDto,
+  PostRecordState,
 } from '@postybirb/types';
 import type { SubmissionRecord } from '../../../../stores/records';
+
+/**
+ * Lifecycle status for an individual website post within a post record.
+ * - 'pending'  : account appears in events (or is expected) but no START yet
+ * - 'running'  : POST_ATTEMPT_STARTED received, no terminal event yet
+ * - 'success'  : POST_ATTEMPT_COMPLETED received
+ * - 'failed'   : POST_ATTEMPT_FAILED received
+ */
+export type DerivedWebsitePostStatus =
+  | 'pending'
+  | 'running'
+  | 'success'
+  | 'failed';
 
 /**
  * Derived website post information from events.
@@ -18,21 +31,28 @@ export interface DerivedWebsitePost {
   accountId: EntityId;
   accountName: string;
   websiteName: string;
-  isSuccess: boolean;
+  status: DerivedWebsitePostStatus;
   sourceUrls: string[];
   errors: string[];
 }
 
 /**
  * Extract website post results from post events.
- * Aggregates events per account to determine success/failure and source URLs.
+ * Aggregates events per account to determine lifecycle status and source URLs.
+ * An account that has only POST_ATTEMPT_STARTED is reported as 'running'
+ * (rather than incorrectly defaulting to 'failed').
  */
 export function extractWebsitePostsFromEvents(
   events: PostEventDto[] | undefined,
 ): DerivedWebsitePost[] {
   if (!events || events.length === 0) return [];
 
-  const postsByAccount = new Map<EntityId, DerivedWebsitePost>();
+  type Accumulator = DerivedWebsitePost & {
+    started: boolean;
+    completed: boolean;
+    failed: boolean;
+  };
+  const postsByAccount = new Map<EntityId, Accumulator>();
 
   for (const event of events) {
     if (!event.accountId) continue;
@@ -47,21 +67,28 @@ export function extractWebsitePostsFromEvents(
         accountName: accountSnapshot?.name ?? 'Unknown',
         // eslint-disable-next-line lingui/no-unlocalized-strings
         websiteName: accountSnapshot?.website ?? '?',
-        isSuccess: false,
+        status: 'pending',
         sourceUrls: [],
         errors: [],
+        started: false,
+        completed: false,
+        failed: false,
       };
       postsByAccount.set(event.accountId, post);
     }
 
     // Process event based on type
     switch (event.eventType) {
+      case PostEventType.POST_ATTEMPT_STARTED:
+        post.started = true;
+        break;
+
       case PostEventType.POST_ATTEMPT_COMPLETED:
-        post.isSuccess = true;
+        post.completed = true;
         break;
 
       case PostEventType.POST_ATTEMPT_FAILED:
-        post.isSuccess = false;
+        post.failed = true;
         if (event.error?.message) {
           post.errors.push(event.error.message);
         }
@@ -86,7 +113,22 @@ export function extractWebsitePostsFromEvents(
     }
   }
 
-  return Array.from(postsByAccount.values());
+  // Classify final status. Order matters: completed > failed > running > pending.
+  return Array.from(postsByAccount.values()).map((p) => {
+    let status: DerivedWebsitePostStatus = 'pending';
+    if (p.completed) status = 'success';
+    else if (p.failed) status = 'failed';
+    else if (p.started) status = 'running';
+
+    return {
+      accountId: p.accountId,
+      accountName: p.accountName,
+      websiteName: p.websiteName,
+      status,
+      sourceUrls: p.sourceUrls,
+      errors: p.errors,
+    };
+  });
 }
 
 /**

--- a/apps/postybirb-ui/src/components/sections/submissions-section/submission-history/history-utils.ts
+++ b/apps/postybirb-ui/src/components/sections/submissions-section/submission-history/history-utils.ts
@@ -36,6 +36,97 @@ export interface DerivedWebsitePost {
   errors: string[];
 }
 
+// =============================================================================
+// Shared per-account event accumulator (used by both extractWebsitePostsFromEvents
+// and getAccountPostStatusMap to avoid duplicating the event classification logic).
+// =============================================================================
+
+interface AccountEventAccumulator {
+  started: boolean;
+  completed: boolean;
+  failed: boolean;
+  errors: string[];
+  sourceUrls: string[];
+  accountName: string;
+  websiteName: string;
+}
+
+/**
+ * Accumulate per-account lifecycle flags from a list of post events.
+ */
+function accumulateAccountEvents(
+  events: PostEventDto[],
+): Map<EntityId, AccountEventAccumulator> {
+  const map = new Map<EntityId, AccountEventAccumulator>();
+
+  for (const event of events) {
+    if (!event.accountId) continue;
+
+    let entry = map.get(event.accountId);
+    if (!entry) {
+      const snap = event.metadata?.accountSnapshot;
+      entry = {
+        started: false,
+        completed: false,
+        failed: false,
+        errors: [],
+        sourceUrls: [],
+        // eslint-disable-next-line lingui/no-unlocalized-strings
+        accountName: snap?.name ?? 'Unknown',
+        // eslint-disable-next-line lingui/no-unlocalized-strings
+        websiteName: snap?.website ?? '?',
+      };
+      map.set(event.accountId, entry);
+    }
+
+    switch (event.eventType) {
+      case PostEventType.POST_ATTEMPT_STARTED:
+        entry.started = true;
+        break;
+      case PostEventType.POST_ATTEMPT_COMPLETED:
+        entry.completed = true;
+        break;
+      case PostEventType.POST_ATTEMPT_FAILED:
+        entry.failed = true;
+        if (event.error?.message) {
+          entry.errors.push(event.error.message);
+        }
+        break;
+      case PostEventType.MESSAGE_POSTED:
+      case PostEventType.FILE_POSTED:
+        if (event.sourceUrl) {
+          entry.sourceUrls.push(event.sourceUrl);
+        }
+        break;
+      case PostEventType.MESSAGE_FAILED:
+      case PostEventType.FILE_FAILED:
+        if (event.error?.message) {
+          entry.errors.push(event.error.message);
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+  return map;
+}
+
+/**
+ * Classify lifecycle flags into a single status.
+ * Priority: completed > failed > started > pending.
+ */
+function classifyStatus(entry: {
+  started: boolean;
+  completed: boolean;
+  failed: boolean;
+}): DerivedWebsitePostStatus {
+  if (entry.completed) return 'success';
+  if (entry.failed) return 'failed';
+  if (entry.started) return 'running';
+  return 'pending';
+}
+
 /**
  * Extract website post results from post events.
  * Aggregates events per account to determine lifecycle status and source URLs.
@@ -47,88 +138,16 @@ export function extractWebsitePostsFromEvents(
 ): DerivedWebsitePost[] {
   if (!events || events.length === 0) return [];
 
-  type Accumulator = DerivedWebsitePost & {
-    started: boolean;
-    completed: boolean;
-    failed: boolean;
-  };
-  const postsByAccount = new Map<EntityId, Accumulator>();
+  const accumulated = accumulateAccountEvents(events);
 
-  for (const event of events) {
-    if (!event.accountId) continue;
-
-    // Get or create post entry for this account
-    let post = postsByAccount.get(event.accountId);
-    if (!post) {
-      const accountSnapshot = event.metadata?.accountSnapshot;
-      post = {
-        accountId: event.accountId,
-        // eslint-disable-next-line lingui/no-unlocalized-strings
-        accountName: accountSnapshot?.name ?? 'Unknown',
-        // eslint-disable-next-line lingui/no-unlocalized-strings
-        websiteName: accountSnapshot?.website ?? '?',
-        status: 'pending',
-        sourceUrls: [],
-        errors: [],
-        started: false,
-        completed: false,
-        failed: false,
-      };
-      postsByAccount.set(event.accountId, post);
-    }
-
-    // Process event based on type
-    switch (event.eventType) {
-      case PostEventType.POST_ATTEMPT_STARTED:
-        post.started = true;
-        break;
-
-      case PostEventType.POST_ATTEMPT_COMPLETED:
-        post.completed = true;
-        break;
-
-      case PostEventType.POST_ATTEMPT_FAILED:
-        post.failed = true;
-        if (event.error?.message) {
-          post.errors.push(event.error.message);
-        }
-        break;
-
-      case PostEventType.MESSAGE_POSTED:
-      case PostEventType.FILE_POSTED:
-        if (event.sourceUrl) {
-          post.sourceUrls.push(event.sourceUrl);
-        }
-        break;
-
-      case PostEventType.MESSAGE_FAILED:
-      case PostEventType.FILE_FAILED:
-        if (event.error?.message) {
-          post.errors.push(event.error.message);
-        }
-        break;
-
-      default:
-        break;
-    }
-  }
-
-  // Classify final status. Order matters: completed > failed > running > pending.
-  return Array.from(postsByAccount.values()).map((p) => {
-    let status: DerivedWebsitePostStatus = 'pending';
-    if (p.completed) status = 'success';
-    else if (p.failed) status = 'failed';
-    else if (p.started) status = 'running';
-
-    return {
-      accountId: p.accountId,
-      accountName: p.accountName,
-      websiteName: p.websiteName,
-      status,
-      sourceUrls: p.sourceUrls,
-      errors: p.errors,
-    };
-  });
+  return Array.from(accumulated.entries()).map(([accountId, entry]) => ({
+    accountId,
+    accountName: entry.accountName,
+    websiteName: entry.websiteName,
+    status: classifyStatus(entry),
+    sourceUrls: entry.sourceUrls,
+    errors: entry.errors,
+  }));
 }
 
 /**
@@ -273,56 +292,15 @@ export function getAccountPostStatusMap(
     return result;
   }
 
-  // Build per-account event state
-  const accountEvents = new Map<
-    EntityId,
-    { started: boolean; completed: boolean; failed: boolean; errors: string[] }
-  >();
+  // Reuse the shared accumulator and classifier
+  const accumulated = accumulateAccountEvents(events);
 
-  for (const event of events) {
-    if (!event.accountId) continue;
-
-    let entry = accountEvents.get(event.accountId);
-    if (!entry) {
-      entry = { started: false, completed: false, failed: false, errors: [] };
-      accountEvents.set(event.accountId, entry);
-    }
-
-    switch (event.eventType) {
-      case PostEventType.POST_ATTEMPT_STARTED:
-        entry.started = true;
-        break;
-      case PostEventType.POST_ATTEMPT_COMPLETED:
-        entry.completed = true;
-        break;
-      case PostEventType.POST_ATTEMPT_FAILED:
-        entry.failed = true;
-        if (event.error?.message) {
-          entry.errors.push(event.error.message);
-        }
-        break;
-      case PostEventType.MESSAGE_FAILED:
-      case PostEventType.FILE_FAILED:
-        if (event.error?.message) {
-          entry.errors.push(event.error.message);
-        }
-        break;
-      default:
-        break;
-    }
-  }
-
-  // Classify each account that has events
-  for (const [accountId, entry] of accountEvents) {
-    if (entry.completed) {
-      result.set(accountId, { status: 'success', errors: [] });
-    } else if (entry.failed) {
-      result.set(accountId, { status: 'failed', errors: entry.errors });
-    } else if (entry.started) {
-      result.set(accountId, { status: 'running', errors: [] });
-    } else {
-      result.set(accountId, { status: 'waiting', errors: [] });
-    }
+  for (const [accountId, entry] of accumulated) {
+    const status = classifyStatus(entry);
+    // Map DerivedWebsitePostStatus to AccountPostStatus
+    const mappedStatus: AccountPostStatus =
+      status === 'pending' ? 'waiting' : status;
+    result.set(accountId, { status: mappedStatus, errors: entry.errors });
   }
 
   // Accounts with options but no events yet are "waiting" (later batch)

--- a/apps/postybirb-ui/src/components/sections/submissions-section/submission-history/post-record-card.tsx
+++ b/apps/postybirb-ui/src/components/sections/submissions-section/submission-history/post-record-card.tsx
@@ -90,8 +90,10 @@ export function PostRecordCard({ record, accountsMap }: PostRecordCardProps) {
 
   // Extract website posts from events
   const websitePosts = extractWebsitePostsFromEvents(record.events);
-  const successCount = websitePosts.filter((p) => p.isSuccess).length;
-  const failedCount = websitePosts.length - successCount;
+  const successCount = websitePosts.filter((p) => p.status === 'success').length;
+  const failedCount = websitePosts.filter((p) => p.status === 'failed').length;
+  const runningCount = websitePosts.filter((p) => p.status === 'running').length;
+  const pendingCount = websitePosts.filter((p) => p.status === 'pending').length;
 
   // Calculate duration if completed
   const startedAt = new Date(record.createdAt);
@@ -119,6 +121,16 @@ export function PostRecordCard({ record, accountsMap }: PostRecordCardProps) {
             {failedCount > 0 && (
               <Badge size="sm" color="red" variant="light">
                 {failedCount} <Trans>failed</Trans>
+              </Badge>
+            )}
+            {runningCount > 0 && (
+              <Badge size="sm" color="blue" variant="light">
+                {runningCount} <Trans>running</Trans>
+              </Badge>
+            )}
+            {pendingCount > 0 && (
+              <Badge size="sm" color="gray" variant="light">
+                {pendingCount} <Trans>waiting</Trans>
               </Badge>
             )}
             {duration && (
@@ -167,43 +179,71 @@ export function PostRecordCard({ record, accountsMap }: PostRecordCardProps) {
                         </Text>
                       </Table.Td>
                       <Table.Td>
-                        {post.isSuccess ? (
-                          <Group gap="xs">
-                            <IconCheck
-                              size={16}
-                              color="var(--mantine-color-green-6)"
-                            />
-                            <Text size="sm" c="green.7">
-                              <Trans>Success</Trans>
-                            </Text>
-                          </Group>
-                        ) : (
-                          <Group gap="xs">
-                            <IconX
-                              size={16}
-                              color="var(--mantine-color-red-6)"
-                            />
-                            <Text size="sm" c="red.7">
-                              <Trans>Failed</Trans>
-                            </Text>
-                            {post.errors.length > 0 && (
-                              <Tooltip
-                                label={post.errors.join(' | ')}
-                                multiline
-                                w={300}
-                                withArrow
-                              >
-                                <ActionIcon
-                                  size="xs"
-                                  variant="subtle"
-                                  color="red"
-                                >
-                                  <IconInfoCircle size={14} />
-                                </ActionIcon>
-                              </Tooltip>
-                            )}
-                          </Group>
-                        )}
+                        {(() => {
+                          switch (post.status) {
+                            case 'success':
+                              return (
+                                <Group gap="xs">
+                                  <IconCheck
+                                    size={16}
+                                    color="var(--mantine-color-green-6)"
+                                  />
+                                  <Text size="sm" c="green.7">
+                                    <Trans>Success</Trans>
+                                  </Text>
+                                </Group>
+                              );
+                            case 'running':
+                              return (
+                                <Group gap="xs">
+                                  <IconLoader
+                                    size={16}
+                                    color="var(--mantine-color-blue-6)"
+                                  />
+                                  <Text size="sm" c="blue.7">
+                                    <Trans>Posting</Trans>
+                                  </Text>
+                                </Group>
+                              );
+                            case 'pending':
+                              return (
+                                <Group gap="xs">
+                                  <Text size="sm" c="dimmed">
+                                    <Trans>Waiting</Trans>
+                                  </Text>
+                                </Group>
+                              );
+                            case 'failed':
+                            default:
+                              return (
+                                <Group gap="xs">
+                                  <IconX
+                                    size={16}
+                                    color="var(--mantine-color-red-6)"
+                                  />
+                                  <Text size="sm" c="red.7">
+                                    <Trans>Failed</Trans>
+                                  </Text>
+                                  {post.errors.length > 0 && (
+                                    <Tooltip
+                                      label={post.errors.join(' | ')}
+                                      multiline
+                                      w={300}
+                                      withArrow
+                                    >
+                                      <ActionIcon
+                                        size="xs"
+                                        variant="subtle"
+                                        color="red"
+                                      >
+                                        <IconInfoCircle size={14} />
+                                      </ActionIcon>
+                                    </Tooltip>
+                                  )}
+                                </Group>
+                              );
+                          }
+                        })()}
                       </Table.Td>
                       <Table.Td>
                         {post.sourceUrls.length > 0 ? (

--- a/apps/postybirb-ui/src/stores/entity/submission-store.ts
+++ b/apps/postybirb-ui/src/stores/entity/submission-store.ts
@@ -63,7 +63,7 @@ function submissionHasChanged(existing: SubmissionRecord, dto: ISubmissionDto): 
   if (dtoOptions.length !== existing.options.length) return true;
   if (dtoOptions.length > 0 && maxUpdatedAt(dtoOptions) !== maxUpdatedAt(existing.options)) return true;
 
-  // 4. Posts changed (count, timestamps, or state)
+  // 4. Posts changed (count, timestamps, state, or events)
   const dtoPosts = dto.posts ?? [];
   if (dtoPosts.length !== existing.posts.length) return true;
   if (dtoPosts.length > 0) {
@@ -72,6 +72,21 @@ function submissionHasChanged(existing: SubmissionRecord, dto: ISubmissionDto): 
     const dtoLatestState = dtoPosts[dtoPosts.length - 1]?.state;
     const existingLatestState = existing.posts[existing.posts.length - 1]?.state;
     if (dtoLatestState !== existingLatestState) return true;
+
+    // Events are a separate table and don't bump the parent post's updatedAt,
+    // so we must check them explicitly to detect new POST_ATTEMPT_STARTED /
+    // POST_ATTEMPT_COMPLETED / etc. events streaming in while a post is running.
+    for (let i = 0; i < dtoPosts.length; i++) {
+      const dtoEvents = dtoPosts[i].events ?? [];
+      const existingEvents = existing.posts[i].events ?? [];
+      if (dtoEvents.length !== existingEvents.length) return true;
+      if (
+        dtoEvents.length > 0 &&
+        maxUpdatedAt(dtoEvents) !== maxUpdatedAt(existingEvents)
+      ) {
+        return true;
+      }
+    }
   }
 
   // 5. PostQueueRecord changed


### PR DESCRIPTION
- Track per-account post lifecycle (pending/running/success/failed) in extractWebsitePostsFromEvents instead of a binary isSuccess flag that defaulted to false, causing in-progress posts to render as Failed
- Update PostRecordCard to render Posting/Waiting/Success/Failed statuses with matching badge counts in the accordion header
- Add event-level change detection in submissionHasChanged so that new PostEvent rows (which don't bump PostRecord.updatedAt) correctly trigger a store update and re-render the history panel while a post is running