### PR TITLE
fix(description): resolve username alias conversion properly and websites without shortcuts

### DIFF
--- a/apps/client-server/src/app/post-parsers/models/description-node.spec.ts
+++ b/apps/client-server/src/app/post-parsers/models/description-node.spec.ts
@@ -517,6 +517,9 @@ describe('DescriptionNode', () => {
             url: 'https://bsky.app/profile/$1',
           },
         },
+        websiteToShortcutId: {
+          bluesky: 'bluesky',
+        },
         customShortcuts: new Map(),
         defaultDescription: [],
         usernameConversions: new Map([['abcd', 'abcd.bsky.app']]),
@@ -1244,6 +1247,9 @@ describe('DescriptionNode', () => {
             url: 'https://test.postybirb.com/$1',
           },
         },
+        websiteToShortcutId: {
+          test: 'test',
+        },
         customShortcuts: new Map(),
         defaultDescription: [],
         usernameConversions: new Map([['myusername', 'converted_username']]),
@@ -1296,6 +1302,210 @@ describe('DescriptionNode', () => {
 
       expect(tree.toPlainText()).toBe('');
       expect(tree.findUsernames().size).toBe(0);
+    });
+  });
+
+  describe('username alias conversions', () => {
+    it('should use target website shortcut format when alias converts username', () => {
+      const nodes: TipTapNode[] = [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'username',
+              attrs: {
+                shortcut: 'other-site',
+                only: '',
+                username: 'OriginalUser',
+              },
+            },
+          ],
+        },
+      ];
+
+      const context: ConversionContext = {
+        website: 'fur-affinity',
+        shortcuts: {
+          'other-site': {
+            id: 'other-site',
+            url: 'https://other-site.com/user/$1',
+          },
+          furaffinity: {
+            id: 'furaffinity',
+            url: 'https://furaffinity.net/user/$1',
+            convert: (websiteName, shortcut) => {
+              if (websiteName === 'fur-affinity' && shortcut === 'furaffinity') {
+                return ':icon$1:';
+              }
+              return undefined;
+            },
+          },
+        },
+        websiteToShortcutId: {
+          'fur-affinity': 'furaffinity',
+        },
+        customShortcuts: new Map(),
+        defaultDescription: [],
+        usernameConversions: new Map([['OriginalUser', 'ConvertedUser']]),
+      };
+
+      const tree = new DescriptionNodeTree(context, nodes, {
+        insertAd: false,
+      });
+
+      expect(tree.toBBCode()).toBe(':iconConvertedUser:');
+      expect(tree.toHtml()).toBe(
+        '<div><span>:iconConvertedUser:</span></div>',
+      );
+      expect(tree.toPlainText()).toBe(':iconConvertedUser:');
+    });
+
+    it('should fall back to original shortcut when target website has no shortcut', () => {
+      const nodes: TipTapNode[] = [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'username',
+              attrs: {
+                shortcut: 'furaffinity',
+                only: '',
+                username: 'OriginalUser',
+              },
+            },
+          ],
+        },
+      ];
+
+      const context: ConversionContext = {
+        website: 'test-no-shortcut',
+        shortcuts: {
+          furaffinity: {
+            id: 'furaffinity',
+            url: 'https://furaffinity.net/user/$1',
+            convert: (websiteName, shortcut) => {
+              if (websiteName === 'fur-affinity' && shortcut === 'furaffinity') {
+                return ':icon$1:';
+              }
+              return undefined;
+            },
+          },
+        },
+        websiteToShortcutId: {},
+        customShortcuts: new Map(),
+        defaultDescription: [],
+        usernameConversions: new Map([['OriginalUser', 'ConvertedUser']]),
+      };
+
+      const tree = new DescriptionNodeTree(context, nodes, {
+        insertAd: false,
+      });
+
+      // Should use the original furaffinity shortcut URL with the converted username
+      expect(tree.toBBCode()).toBe(
+        '[url=https://furaffinity.net/user/ConvertedUser]ConvertedUser[/url]',
+      );
+      expect(tree.toHtml()).toBe(
+        '<div><a target="_blank" href="https://furaffinity.net/user/ConvertedUser">ConvertedUser</a></div>',
+      );
+      expect(tree.toPlainText()).toBe(
+        'https://furaffinity.net/user/ConvertedUser',
+      );
+    });
+
+    it('should not alter output when no alias conversion exists for a username', () => {
+      const nodes: TipTapNode[] = [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'username',
+              attrs: {
+                shortcut: 'furaffinity',
+                only: '',
+                username: 'SomeUser',
+              },
+            },
+          ],
+        },
+      ];
+
+      const context: ConversionContext = {
+        website: 'fur-affinity',
+        shortcuts: {
+          furaffinity: {
+            id: 'furaffinity',
+            url: 'https://furaffinity.net/user/$1',
+            convert: (websiteName, shortcut) => {
+              if (websiteName === 'fur-affinity' && shortcut === 'furaffinity') {
+                return ':icon$1:';
+              }
+              return undefined;
+            },
+          },
+        },
+        websiteToShortcutId: {
+          'fur-affinity': 'furaffinity',
+        },
+        customShortcuts: new Map(),
+        defaultDescription: [],
+        usernameConversions: new Map(),
+      };
+
+      const tree = new DescriptionNodeTree(context, nodes, {
+        insertAd: false,
+      });
+
+      // No conversion — uses original shortcut with original username
+      expect(tree.toBBCode()).toBe(':iconSomeUser:');
+      expect(tree.toHtml()).toBe('<div><span>:iconSomeUser:</span></div>');
+    });
+
+    it('should convert username but keep original shortcut format when same as target', () => {
+      const nodes: TipTapNode[] = [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'username',
+              attrs: {
+                shortcut: 'furaffinity',
+                only: '',
+                username: 'OldName',
+              },
+            },
+          ],
+        },
+      ];
+
+      const context: ConversionContext = {
+        website: 'fur-affinity',
+        shortcuts: {
+          furaffinity: {
+            id: 'furaffinity',
+            url: 'https://furaffinity.net/user/$1',
+            convert: (websiteName, shortcut) => {
+              if (websiteName === 'fur-affinity' && shortcut === 'furaffinity') {
+                return ':icon$1:';
+              }
+              return undefined;
+            },
+          },
+        },
+        websiteToShortcutId: {
+          'fur-affinity': 'furaffinity',
+        },
+        customShortcuts: new Map(),
+        defaultDescription: [],
+        usernameConversions: new Map([['OldName', 'NewName']]),
+      };
+
+      const tree = new DescriptionNodeTree(context, nodes, {
+        insertAd: false,
+      });
+
+      expect(tree.toBBCode()).toBe(':iconNewName:');
+      expect(tree.toHtml()).toBe('<div><span>:iconNewName:</span></div>');
     });
   });
 });

--- a/apps/client-server/src/app/post-parsers/models/description-node/converters/base-converter.ts
+++ b/apps/client-server/src/app/post-parsers/models/description-node/converters/base-converter.ts
@@ -176,7 +176,15 @@ export abstract class BaseConverter {
     const converted = context.usernameConversions?.get(username);
     if (converted && converted !== username) {
       convertedUsername = converted;
-      effectiveShortcutId = context.website;
+      // Use the shortcut ID registered for the target website so the
+      // website-specific convert function (e.g. :icon$1: for FA) is invoked.
+      // If the target website has no shortcut, keep the original shortcut so
+      // the link still renders using the original URL template.
+      const targetShortcutId =
+        context.websiteToShortcutId?.[context.website];
+      if (targetShortcutId && context.shortcuts[targetShortcutId]) {
+        effectiveShortcutId = targetShortcutId;
+      }
     }
 
     const shortcut: UsernameShortcut | undefined =

--- a/apps/client-server/src/app/post-parsers/models/description-node/description-node.base.ts
+++ b/apps/client-server/src/app/post-parsers/models/description-node/description-node.base.ts
@@ -7,6 +7,8 @@ import { TipTapNode } from './description-node.types';
 export interface ConversionContext {
   website: string;
   shortcuts: Record<string, UsernameShortcut>;
+  /** Maps website metadata name to the shortcut ID for that website */
+  websiteToShortcutId?: Record<string, string>;
   customShortcuts: Map<string, TipTapNode[]>;
   defaultDescription: TipTapNode[];
   title?: string;

--- a/apps/client-server/src/app/post-parsers/parsers/description-parser.service.ts
+++ b/apps/client-server/src/app/post-parsers/parsers/description-parser.service.ts
@@ -23,6 +23,7 @@ import { ConversionContext } from '../models/description-node/description-node.b
 @Injectable()
 export class DescriptionParserService {
   private readonly websiteShortcuts: Record<string, UsernameShortcut> = {};
+  private readonly websiteToShortcutId: Record<string, string> = {};
 
   constructor(
     private readonly settingsService: SettingsService,
@@ -36,6 +37,11 @@ export class DescriptionParserService {
         website.prototype.decoratedProps.usernameShortcut;
       if (shortcut) {
         this.websiteShortcuts[shortcut.id] = shortcut;
+        const websiteName: string =
+          website.prototype.decoratedProps.metadata?.name;
+        if (websiteName) {
+          this.websiteToShortcutId[websiteName] = shortcut.id;
+        }
       }
     });
   }
@@ -114,6 +120,7 @@ export class DescriptionParserService {
     const context: ConversionContext = {
       website: instance.decoratedProps.metadata.name,
       shortcuts: this.websiteShortcuts,
+      websiteToShortcutId: this.websiteToShortcutId,
       customShortcuts: new Map(),
       defaultDescription,
       title,


### PR DESCRIPTION
Username alias conversions were failing because the converter used the
website metadata name (e.g. "fur-affinity") to look up shortcuts keyed
by shortcut ID (e.g. "furaffinity"). This caused converted usernames to
disappear entirely in BBCode output (FurAffinity :icon: format) and on
websites without a registered username shortcut.

- Add websiteToShortcutId mapping to resolve website names to shortcut IDs
- Fall back to the original shortcut when target website has no shortcut