### PR TITLE
tumblr: bump GIF size to 10MB

### DIFF
--- a/apps/client-server/src/app/websites/implementations/tumblr/tumblr.website.ts
+++ b/apps/client-server/src/app/websites/implementations/tumblr/tumblr.website.ts
@@ -79,7 +79,7 @@ type TumblrPostResponse = {
     [FileType.AUDIO]: FileSize.megabytes(10),
     [FileType.VIDEO]: FileSize.megabytes(500),
     [FileType.IMAGE]: FileSize.megabytes(20),
-    'image/gif': FileSize.megabytes(3),
+    'image/gif': FileSize.megabytes(10),
   },
 })
 export default class Tumblr


### PR DESCRIPTION
Looks like Tumblr will now take GIFs up to at least 10MB: https://help.tumblr.com/knowledge-base/image-gif-troubleshooting/

I think this doc is a little out of date, since Tumblr now seems to be willing to serve up non-gifv converted GIFs at a higher size than that doc claims they will. I recently did a manual upload of a 7.8MB GIF without issues.