### PR TITLE
fix: select option warning

### DIFF
--- a/apps/client-server/src/app/validation/validators/select-field-validators.ts
+++ b/apps/client-server/src/app/validation/validators/select-field-validators.ts
@@ -82,9 +82,9 @@ export async function validateSelectFieldValidOptions({
     if (field.allowMultiple) {
       // For multi-select, validate each selected value
       if (Array.isArray(currentValue)) {
-        const invalidOptions = currentValue
-          .filter((value) => !availableOptions.includes(value))
-          .map((e) => e + ' ' + availableOptions.join(' '));
+        const invalidOptions = currentValue.filter(
+          (value) => !availableOptions.includes(value),
+        );
 
         if (invalidOptions.length > 0) {
           validator.error(
@@ -98,7 +98,7 @@ export async function validateSelectFieldValidOptions({
       // For single-select, validate the selected value
       validator.error(
         'validation.select-field.invalid-option',
-        { invalidOptions: [currentValue + ' ' + availableOptions.join(' ')] },
+        { invalidOptions: [currentValue] },
         fieldName,
       );
     }

--- a/apps/client-server/src/app/validation/validators/select-field-validators.ts
+++ b/apps/client-server/src/app/validation/validators/select-field-validators.ts
@@ -77,13 +77,14 @@ export async function validateSelectFieldValidOptions({
 
     // Flatten all available options to a simple array of values
     const availableOptions = flattenSelectOptions(field.options);
+    if (!availableOptions.length) continue;
 
     if (field.allowMultiple) {
       // For multi-select, validate each selected value
       if (Array.isArray(currentValue)) {
-        const invalidOptions = currentValue.filter(
-          (value) => !availableOptions.includes(value),
-        );
+        const invalidOptions = currentValue
+          .filter((value) => !availableOptions.includes(value))
+          .map((e) => e + ' ' + availableOptions.join(' '));
 
         if (invalidOptions.length > 0) {
           validator.error(
@@ -97,7 +98,7 @@ export async function validateSelectFieldValidOptions({
       // For single-select, validate the selected value
       validator.error(
         'validation.select-field.invalid-option',
-        { invalidOptions: [currentValue] },
+        { invalidOptions: [currentValue + ' ' + availableOptions.join(' ')] },
         fieldName,
       );
     }


### PR DESCRIPTION
Caused by #838 
Previously due to a bug select options were undefined and thus ignored
Now it needs to be implicily checked if the array is empty