### PR TITLE
feat(tja): require gallery folder selection before submitting

### DIFF
--- a/apps/client-server/src/app/websites/implementations/thejabarchives/models/tja-file-submission.ts
+++ b/apps/client-server/src/app/websites/implementations/thejabarchives/models/tja-file-submission.ts
@@ -4,6 +4,7 @@ import { TJAAccountData } from './tja-account-data';
 
 export class TJAFileSubmission extends BaseWebsiteOptions {
   @SelectField<TJAAccountData>({
+    required: true,
     label: 'folder',
     section: 'website',
     derive: [

--- a/apps/client-server/src/app/websites/implementations/thejabarchives/tja.website.ts
+++ b/apps/client-server/src/app/websites/implementations/thejabarchives/tja.website.ts
@@ -116,8 +116,8 @@ export default class TheJabArchives
       .asMultipart()
       .setField('gallery_id', options.galleryId ?? '')
       .setField('title', options.title)
-      .setField('tags', options.tags.join(', '))
-      .setField('description', options.description ?? '')
+      .setField('tags', options.tags.tags.join(', '))
+      .setField('description', options.description.description ?? '')
       .addFile('file', files[0])
       .send<{ success: boolean; id: number; url: string }>(
         `${this.BASE_URL}/api/v1/submit.php`,

--- a/apps/client-server/src/app/websites/implementations/thejabarchives/tja.website.ts
+++ b/apps/client-server/src/app/websites/implementations/thejabarchives/tja.website.ts
@@ -116,8 +116,8 @@ export default class TheJabArchives
       .asMultipart()
       .setField('gallery_id', options.galleryId ?? '')
       .setField('title', options.title)
-      .setField('tags', options.tags.tags.join(', '))
-      .setField('description', options.description.description ?? '')
+      .setField('tags', options.tags.join(', '))
+      .setField('description', options.description ?? '')
       .addFile('file', files[0])
       .send<{ success: boolean; id: number; url: string }>(
         `${this.BASE_URL}/api/v1/submit.php`,


### PR DESCRIPTION
## Summary

Marks the gallery Folder field as `required: true` in `TJAFileSubmission` so PostyBirb validates that a gallery is selected before allowing a submission to be queued.

Without this, the field is optional in the UI and an empty `gallery_id` is sent to the API.
