### PR TITLE
fix(eslint): scope parserOptions.project per Nx project to prevent OOM

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,6 @@ const config = {
     'eslint-config-prettier',
   ],
   plugins: ['@nx', 'jest'],
-  parserOptions: { project: './tsconfig.base.json' },
   overrides: [
     {
       files: ['*.tsx'],

--- a/apps/client-server/.eslintrc.json
+++ b/apps/client-server/.eslintrc.json
@@ -8,6 +8,9 @@
     },
     {
       "files": ["*.ts", "*.tsx"],
+      "parserOptions": {
+        "project": ["apps/client-server/tsconfig.*?.json"]
+      },
       "rules": {}
     },
     {

--- a/apps/postybirb-ui/.eslintrc.json
+++ b/apps/postybirb-ui/.eslintrc.json
@@ -29,6 +29,9 @@
     },
     {
       "files": ["*.ts", "*.tsx"],
+      "parserOptions": {
+        "project": ["apps/postybirb-ui/tsconfig.*?.json"]
+      },
       "rules": {}
     },
     {

--- a/apps/postybirb/.eslintrc.json
+++ b/apps/postybirb/.eslintrc.json
@@ -8,6 +8,9 @@
     },
     {
       "files": ["*.ts", "*.tsx"],
+      "parserOptions": {
+        "project": ["apps/postybirb/tsconfig.*?.json"]
+      },
       "rules": {}
     },
     {

--- a/libs/database/.eslintrc.json
+++ b/libs/database/.eslintrc.json
@@ -8,6 +8,9 @@
     },
     {
       "files": ["*.ts", "*.tsx"],
+      "parserOptions": {
+        "project": ["libs/database/tsconfig.*?.json"]
+      },
       "rules": {}
     },
     {

--- a/libs/form-builder/.eslintrc.json
+++ b/libs/form-builder/.eslintrc.json
@@ -8,6 +8,9 @@
     },
     {
       "files": ["*.ts", "*.tsx"],
+      "parserOptions": {
+        "project": ["libs/form-builder/tsconfig.*?.json"]
+      },
       "rules": {}
     },
     {

--- a/libs/fs/.eslintrc.json
+++ b/libs/fs/.eslintrc.json
@@ -8,6 +8,9 @@
     },
     {
       "files": ["*.ts", "*.tsx"],
+      "parserOptions": {
+        "project": ["libs/fs/tsconfig.*?.json"]
+      },
       "rules": {}
     },
     {

--- a/libs/http/.eslintrc.json
+++ b/libs/http/.eslintrc.json
@@ -8,6 +8,9 @@
     },
     {
       "files": ["*.ts", "*.tsx"],
+      "parserOptions": {
+        "project": ["libs/http/tsconfig.*?.json"]
+      },
       "rules": {}
     },
     {

--- a/libs/logger/.eslintrc.json
+++ b/libs/logger/.eslintrc.json
@@ -8,6 +8,9 @@
     },
     {
       "files": ["*.ts", "*.tsx"],
+      "parserOptions": {
+        "project": ["libs/logger/tsconfig.*?.json"]
+      },
       "rules": {}
     },
     {

--- a/libs/platform/.eslintrc.json
+++ b/libs/platform/.eslintrc.json
@@ -8,6 +8,9 @@
     },
     {
       "files": ["*.ts", "*.tsx"],
+      "parserOptions": {
+        "project": ["libs/platform/tsconfig.*?.json"]
+      },
       "rules": {}
     },
     {

--- a/libs/socket-events/.eslintrc.json
+++ b/libs/socket-events/.eslintrc.json
@@ -8,6 +8,9 @@
     },
     {
       "files": ["*.ts", "*.tsx"],
+      "parserOptions": {
+        "project": ["libs/socket-events/tsconfig.*?.json"]
+      },
       "rules": {}
     },
     {

--- a/libs/translations/.eslintrc.json
+++ b/libs/translations/.eslintrc.json
@@ -8,6 +8,9 @@
     },
     {
       "files": ["*.ts", "*.tsx"],
+      "parserOptions": {
+        "project": ["libs/translations/tsconfig.*?.json"]
+      },
       "rules": {}
     },
     {

--- a/libs/types/.eslintrc.json
+++ b/libs/types/.eslintrc.json
@@ -8,6 +8,9 @@
     },
     {
       "files": ["*.ts", "*.tsx"],
+      "parserOptions": {
+        "project": ["libs/types/tsconfig.*?.json"]
+      },
       "rules": {}
     },
     {

--- a/libs/utils/common/.eslintrc.json
+++ b/libs/utils/common/.eslintrc.json
@@ -8,6 +8,9 @@
     },
     {
       "files": ["*.ts", "*.tsx"],
+      "parserOptions": {
+        "project": ["libs/utils/common/tsconfig.*?.json"]
+      },
       "rules": {}
     },
     {

--- a/libs/utils/file-type/.eslintrc.json
+++ b/libs/utils/file-type/.eslintrc.json
@@ -8,6 +8,9 @@
     },
     {
       "files": ["*.ts", "*.tsx"],
+      "parserOptions": {
+        "project": ["libs/utils/file-type/tsconfig.*?.json"]
+      },
       "rules": {}
     },
     {


### PR DESCRIPTION
Remove workspace-wide tsconfig.base.json from root ESLint parserOptions and configure project-scoped tsconfig globs in each Nx project to avoid building the entire monorepo TypeScript program during lint.