### PR TITLE
fix(database): prevent and recover from migration 0008 default website options data loss

### DIFF
--- a/apps/client-server/src/app/submission/services/submission.service.ts
+++ b/apps/client-server/src/app/submission/services/submission.service.ts
@@ -94,11 +94,85 @@ export class SubmissionService
 
   async onModuleInit() {
     await this.cleanupUninitializedSubmissions();
+    await this.recreateMissingDefaultOptions();
     await this.normalizeOrders();
     for (const type of Object.values(SubmissionType)) {
       // eslint-disable-next-line no-await-in-loop
       await this.populateMultiSubmission(type);
     }
+  }
+
+  /**
+   * Self-healing pass that restores the default (NULL_ACCOUNT) website option
+   * for any submission missing it.
+   *
+   * Every submission is expected to have exactly one default option (created
+   * during {@link create}). A destructive migration cascade-deleted
+   * `website-options` rows on some databases, leaving pre-existing submissions
+   * without their default option. This recreates any that are missing so the
+   * database is whole again. Account-specific options and stored login data are
+   * not recoverable here (no source survives); website data rows are
+   * re-created lazily on website initialization, and accounts must be
+   * re-authenticated.
+   */
+  private async recreateMissingDefaultOptions() {
+    const submissions = await this.repository.findAll();
+    let recreated = 0;
+
+    for (const submission of submissions) {
+      const hasDefault = (submission.options ?? []).some(
+        (option) =>
+          option.isDefault || option.accountId === NULL_ACCOUNT_ID,
+      );
+      if (hasDefault) {
+        continue;
+      }
+
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        await this.websiteOptionsService.createDefaultSubmissionOptions(
+          submission,
+          this.deriveRecoveryTitle(submission),
+        );
+        recreated++;
+      } catch (err) {
+        this.logger
+          .withError(toError(err))
+          .withMetadata({ id: submission.id })
+          .error('Failed to recreate missing default website option');
+      }
+    }
+
+    if (recreated > 0) {
+      this.logger.warn(
+        `Recreated ${recreated} missing default website option(s)`,
+      );
+    }
+  }
+
+  /**
+   * Derives a best-effort title for a recreated default option, preferring any
+   * surviving option title, then a file name, then the template/submission
+   * name.
+   */
+  private deriveRecoveryTitle(submission: SubmissionEntity): string {
+    const survivingTitle = (submission.options ?? [])
+      .map((option) => option.data?.title)
+      .find((title) => typeof title === 'string' && title.trim().length > 0);
+    if (survivingTitle) {
+      return survivingTitle;
+    }
+
+    const firstFile = (submission.files ?? [])[0];
+    if (firstFile?.fileName) {
+      return path.parse(firstFile.fileName).name;
+    }
+
+    if (submission.metadata?.template?.name) {
+      return submission.metadata.template.name;
+    }
+
+    return submission.isMultiSubmission ? submission.type : 'New submission';
   }
 
   /**

--- a/apps/postybirb/src/migrations/0008_windy_kinsey_walden.sql
+++ b/apps/postybirb/src/migrations/0008_windy_kinsey_walden.sql
@@ -1,20 +1,3 @@
 DROP TABLE `user-specified-website-options`;--> statement-breakpoint
-PRAGMA foreign_keys=OFF;--> statement-breakpoint
-CREATE TABLE `__new_account` (
-	`id` text PRIMARY KEY NOT NULL,
-	`createdAt` text NOT NULL,
-	`updatedAt` text NOT NULL,
-	`groups` text NOT NULL,
-	`name` text NOT NULL,
-	`website` text NOT NULL,
-	`defaultFileTemplateId` text,
-	`defaultMessageTemplateId` text,
-	FOREIGN KEY (`defaultFileTemplateId`) REFERENCES `submission`(`id`) ON UPDATE no action ON DELETE set null,
-	FOREIGN KEY (`defaultMessageTemplateId`) REFERENCES `submission`(`id`) ON UPDATE no action ON DELETE set null
-);
---> statement-breakpoint
-INSERT INTO `__new_account`("id", "createdAt", "updatedAt", "groups", "name", "website") SELECT "id", "createdAt", "updatedAt", "groups", "name", "website" FROM `account`;--> statement-breakpoint
-DROP TABLE `account`;--> statement-breakpoint
-ALTER TABLE `__new_account` RENAME TO `account`;--> statement-breakpoint
-PRAGMA foreign_keys=ON;--> statement-breakpoint
-CREATE UNIQUE INDEX `account_id_unique` ON `account` (`id`);
+ALTER TABLE `account` ADD `defaultFileTemplateId` text REFERENCES `submission`(`id`) ON UPDATE no action ON DELETE set null;--> statement-breakpoint
+ALTER TABLE `account` ADD `defaultMessageTemplateId` text REFERENCES `submission`(`id`) ON UPDATE no action ON DELETE set null;

--- a/docs/postmortems/2026-06-24-default-website-options-data-loss.md
+++ b/docs/postmortems/2026-06-24-default-website-options-data-loss.md
@@ -1,9 +1,13 @@
 # Postmortem: Loss of Default Website Options After 4.0.40 Upgrade
 
 **Status:** Resolved
+
 **Severity:** SEV1 — silent user data loss
-**Author:** Engineering
+
+**Author:** mvdicarlo
+
 **Date of incident:** 2026-06-24 (first user reports, following the 4.0.40 release)
+
 **Date of writeup:** 2026-06-26
 
 ---
@@ -17,14 +21,14 @@ had created before updating. It also **logged everyone out** of their connected
 websites.
 
 The cause was a database upgrade that rebuilt an internal table while a safety
-switch that was *supposed* to prevent collateral deletion was silently ignored.
+switch that was _supposed_ to prevent collateral deletion was silently ignored.
 When the old table was removed, the database automatically deleted related
 records that pointed to it.
 
 **What we did:**
 
 - Fixed the faulty upgrade step so it no longer deletes anything (it now only
-  *adds* what it needs).
+  _adds_ what it needs).
 - Added an automatic recovery step that rebuilds the missing default options the
   next time the app starts.
 - Added **automatic database backups taken right before any future upgrade**, so
@@ -68,7 +72,7 @@ will no longer be in a broken state.
   - The `user-specified-website-options` table — saved account default templates
     (this table was intentionally removed by the refactor, but with no data
     migration into the new model).
-- **What was *not* affected:**
+- **What was _not_ affected:**
   - `post-event` history (its account reference is `ON DELETE SET NULL`, so those
     rows survived with the account link cleared).
   - Submissions, files, and other core records themselves.
@@ -79,13 +83,13 @@ will no longer be in a broken state.
 
 ## Timeline
 
-| When | Event |
-| --- | --- |
-| 2026-06-23 | PR #919 (`54cc281`) merged — "use templates as backing for user defaults", including auto-generated migration `0008`. |
-| ~2026-06-23 | Release **4.0.40** cut (`1d4b416`). |
-| 2026-06-24 | First user reports: default website options "disappeared" on existing submissions. |
-| 2026-06-25 | Issue reproduced internally; suspicion focused on `54cc281`. |
-| 2026-06-26 | Root cause confirmed empirically; migration rewritten, recovery + safeguards added. |
+| When        | Event                                                                                                                 |
+| ----------- | --------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-23  | PR #919 (`54cc281`) merged — "use templates as backing for user defaults", including auto-generated migration `0008`. |
+| ~2026-06-23 | Release **4.0.40** cut (`1d4b416`).                                                                                   |
+| 2026-06-24  | First user reports: default website options "disappeared" on existing submissions.                                    |
+| 2026-06-25  | Issue reproduced internally; suspicion focused on `54cc281`.                                                          |
+| 2026-06-26  | Root cause confirmed empirically; migration rewritten, recovery + safeguards added.                                   |
 
 ---
 
@@ -228,19 +232,19 @@ it before release.
 
 ## Remedies / Action Items
 
-| # | Action | Status |
-| --- | --- | --- |
-| 1 | Rewrite migration `0008` to be additive (no table rebuild). | ✅ Done |
-| 2 | Self-healing pass to recreate missing default website options on startup. | ✅ Done |
-| 3 | **Automatic pre-migration backups** — consistent `VACUUM INTO` snapshot taken only when migrations are pending, stored in a `backups/` subfolder, retaining the 5 most recent. | ✅ Done |
-| 4 | **Migration integrity tests** — seed representative data, run migrations as production does (FKs on, in a transaction), and assert data survives; plus a generic guard that fails for any future migration that destroys seeded data. | ✅ Done |
-| 5 | Prefer additive migrations; treat any generated `DROP TABLE` / table-rebuild as a red flag requiring explicit review. | ⏳ Process |
-| 6 | Document the FK-pragma trap: the in-SQL `PRAGMA foreign_keys=OFF` is ignored inside drizzle's transaction. If a rebuild is truly required, toggle FKs on the connection *outside* `migrate()`. | ⏳ Process |
-| 7 | Unit tests for the new recovery and backup logic. | ⏳ Planned |
-| 8 | User-facing restore path (list/restore a backup) instead of manual file swaps. | ⏳ Planned |
-| 9 | Decide whether to backfill the dropped `user-specified-website-options` (saved account defaults) into the new template model. | ⏳ Decision needed |
-| 10 | Add monitoring/alerting for unexpected mass row deletion so future incidents are detected automatically, not via user reports. | ⏳ Planned |
-| 11 | Apply the upstream-recommended workaround for [drizzle-orm#5782](https://github.com/drizzle-team/drizzle-orm/issues/5782): toggle `foreign_keys = OFF` on the raw connection **before** `migrate()` and restore it in a `finally`, so any future table-rebuild migration cannot silently cascade-delete. Revisit once the upstream fix (PR #5784) ships and drizzle is upgraded. | ⏳ Recommended |
+| #   | Action                                                                                                                                                                                                                                                                                                                                                                           | Status             |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| 1   | Rewrite migration `0008` to be additive (no table rebuild).                                                                                                                                                                                                                                                                                                                      | ✅ Done            |
+| 2   | Self-healing pass to recreate missing default website options on startup.                                                                                                                                                                                                                                                                                                        | ✅ Done            |
+| 3   | **Automatic pre-migration backups** — consistent `VACUUM INTO` snapshot taken only when migrations are pending, stored in a `backups/` subfolder, retaining the 5 most recent.                                                                                                                                                                                                   | ✅ Done            |
+| 4   | **Migration integrity tests** — seed representative data, run migrations as production does (FKs on, in a transaction), and assert data survives; plus a generic guard that fails for any future migration that destroys seeded data.                                                                                                                                            | ✅ Done            |
+| 5   | Prefer additive migrations; treat any generated `DROP TABLE` / table-rebuild as a red flag requiring explicit review.                                                                                                                                                                                                                                                            | ⏳ Process         |
+| 6   | Document the FK-pragma trap: the in-SQL `PRAGMA foreign_keys=OFF` is ignored inside drizzle's transaction. If a rebuild is truly required, toggle FKs on the connection _outside_ `migrate()`.                                                                                                                                                                                   | ⏳ Process         |
+| 7   | Unit tests for the new recovery and backup logic.                                                                                                                                                                                                                                                                                                                                | ⏳ Planned         |
+| 8   | User-facing restore path (list/restore a backup) instead of manual file swaps.                                                                                                                                                                                                                                                                                                   | ⏳ Planned         |
+| 9   | Decide whether to backfill the dropped `user-specified-website-options` (saved account defaults) into the new template model.                                                                                                                                                                                                                                                    | ⏳ Decision needed |
+| 10  | Add monitoring/alerting for unexpected mass row deletion so future incidents are detected automatically, not via user reports.                                                                                                                                                                                                                                                   | ⏳ Planned         |
+| 11  | Apply the upstream-recommended workaround for [drizzle-orm#5782](https://github.com/drizzle-team/drizzle-orm/issues/5782): toggle `foreign_keys = OFF` on the raw connection **before** `migrate()` and restore it in a `finally`, so any future table-rebuild migration cannot silently cascade-delete. Revisit once the upstream fix (PR #5784) ships and drizzle is upgraded. | ⏳ Recommended     |
 
 ---
 
@@ -280,7 +284,7 @@ path for already-upgraded users without a personal backup.
   — proposed upstream fix (hoist `PRAGMA foreign_keys` before `BEGIN`).
 - [drizzle-team/drizzle-orm#1813](https://github.com/drizzle-team/drizzle-orm/issues/1813)
   and [#4089](https://github.com/drizzle-team/drizzle-orm/issues/4089) — the
-  long-standing *loud* (`NO ACTION`) variant of the same bug.
+  long-standing _loud_ (`NO ACTION`) variant of the same bug.
 - [SQLite: PRAGMA foreign_keys](https://www.sqlite.org/pragma.html#pragma_foreign_keys)
   — "This pragma is a no-op within a transaction."
 - [SQLite: DROP TABLE](https://www.sqlite.org/lang_droptable.html) — implicit

--- a/docs/postmortems/2026-06-24-default-website-options-data-loss.md
+++ b/docs/postmortems/2026-06-24-default-website-options-data-loss.md
@@ -1,0 +1,270 @@
+# Postmortem: Loss of Default Website Options After 4.0.40 Upgrade
+
+**Status:** Resolved
+**Severity:** SEV1 — silent user data loss
+**Author:** Engineering
+**Date of incident:** 2026-06-24 (first user reports, following the 4.0.40 release)
+**Date of writeup:** 2026-06-26
+
+---
+
+## TL;DR (for everyone)
+
+When users updated PostyBirb to version **4.0.40**, the app ran a one-time database
+upgrade step. A mistake in that step accidentally **deleted the saved "default"
+posting options** (tags, description, rating, etc.) from every submission people
+had created before updating. It also **logged everyone out** of their connected
+websites.
+
+The cause was a database upgrade that rebuilt an internal table while a safety
+switch that was *supposed* to prevent collateral deletion was silently ignored.
+When the old table was removed, the database automatically deleted related
+records that pointed to it.
+
+**What we did:**
+
+- Fixed the faulty upgrade step so it no longer deletes anything (it now only
+  *adds* what it needs).
+- Added an automatic recovery step that rebuilds the missing default options the
+  next time the app starts.
+- Added **automatic database backups taken right before any future upgrade**, so
+  data can always be recovered.
+- Added **automated tests that will block any future upgrade that destroys
+  data** before it can ship.
+
+**What users need to know:** Connected accounts need to be **signed in again**
+(their login data could not be recovered). The values previously typed into
+default options can only be fully restored from a personal backup, but the app
+will no longer be in a broken state.
+
+---
+
+## Impact
+
+- **Who:** All users who upgraded to 4.0.40 with pre-existing submissions.
+- **What was lost:**
+  - All `website-options` rows — the per-submission posting options, including the
+    shared **default (null-account)** option that nearly every submission has.
+  - All `website-data` rows — stored website login/session data, effectively
+    signing users out of every connected website.
+  - The `user-specified-website-options` table — saved account default templates
+    (this table was intentionally removed by the refactor, but with no data
+    migration into the new model).
+- **What was *not* affected:**
+  - `post-event` history (its account reference is `ON DELETE SET NULL`, so those
+    rows survived with the account link cleared).
+  - Submissions, files, and other core records themselves.
+- **Detection:** Via user reports shortly after release, not by automated
+  monitoring.
+
+---
+
+## Timeline
+
+| When | Event |
+| --- | --- |
+| 2026-06-23 | PR #919 (`54cc281`) merged — "use templates as backing for user defaults", including auto-generated migration `0008`. |
+| ~2026-06-23 | Release **4.0.40** cut (`1d4b416`). |
+| 2026-06-24 | First user reports: default website options "disappeared" on existing submissions. |
+| 2026-06-25 | Issue reproduced internally; suspicion focused on `54cc281`. |
+| 2026-06-26 | Root cause confirmed empirically; migration rewritten, recovery + safeguards added. |
+
+---
+
+## Root Cause
+
+Migration `apps/postybirb/src/migrations/0008_windy_kinsey_walden.sql` added two
+nullable foreign-key columns to the `account` table. Instead of an additive
+change, the drizzle-kit-generated migration performed a **full table rebuild**:
+
+```sql
+PRAGMA foreign_keys=OFF;
+CREATE TABLE `__new_account` ( ... );
+INSERT INTO `__new_account` (...) SELECT ... FROM `account`;
+DROP TABLE `account`;
+ALTER TABLE `__new_account` RENAME TO `account`;
+PRAGMA foreign_keys=ON;
+```
+
+Two facts combined to make this destructive:
+
+1. The application opens the database with `PRAGMA foreign_keys = ON`
+   (`libs/database/src/lib/database.ts`).
+2. Drizzle's better-sqlite3 migrator runs all migration statements **inside a
+   single transaction**.
+
+In SQLite, **`PRAGMA foreign_keys` is a no-op inside a transaction** — foreign-key
+enforcement can only be toggled when no transaction is open. So the migration's
+`PRAGMA foreign_keys=OFF` did nothing, and foreign keys remained enforced.
+
+With foreign keys enforced, `DROP TABLE account` performs an implicit delete of
+all `account` rows, which triggers `ON DELETE CASCADE` on the children that
+reference it — `website-options` and `website-data` — deleting all of their rows.
+
+This was confirmed by reproducing the exact pattern: inside a transaction the
+`foreign_keys` pragma stayed `1`, and `DROP TABLE account` took the child
+`website-options` row count from 2 to 0.
+
+### This is a known upstream framework bug
+
+The behavior is documented as a drizzle-orm bug:
+[drizzle-team/drizzle-orm#5782](https://github.com/drizzle-team/drizzle-orm/issues/5782)
+— "SQLite table-rebuild migrations silently wipe child tables for any FK with
+`ON DELETE CASCADE`." Three individually-correct pieces combine into a silent
+data-loss event:
+
+1. drizzle-kit's table-rebuild codegen prepends `PRAGMA foreign_keys=OFF;` to
+   disarm cascades during the rebuild (correct in intent).
+2. drizzle-orm's migrator wraps every migration in a single `BEGIN ... COMMIT`
+   so partial migrations roll back (reasonable).
+3. SQLite treats `PRAGMA foreign_keys` as a **no-op inside a transaction**, so
+   the guard in (1) is silently neutralized by (2).
+
+Crucially, the failure mode depends on the child FK's `ON DELETE` action:
+
+- `NO ACTION` (default) → the implicit delete **fails loudly** with
+  `SQLITE_CONSTRAINT: FOREIGN KEY constraint failed` and rolls back (the
+  long-standing, visible variant: issues #1813 / #4089).
+- `ON DELETE CASCADE` (our case) → SQLite **silently deletes** every dependent
+  row, the `DROP TABLE` succeeds, and the migration commits as applied. No error,
+  no log — the only signal is that user data vanished.
+
+A fix (hoisting the pragma before `BEGIN`) is proposed upstream in PR #5784 but
+was not yet merged at the time of this incident. Note that `PRAGMA
+defer_foreign_keys` does **not** fix it — SQLite performs FK cascading actions
+immediately even when constraint checks are deferred. The only reliable approach
+is to toggle `foreign_keys` on the connection **outside** the transaction.
+
+---
+
+## The 5 Whys
+
+1. **Why did users' default website options disappear?**
+   The `website-options` rows (including the default/null-account option) were
+   deleted from the database during the 4.0.40 upgrade.
+
+2. **Why were the `website-options` rows deleted?**
+   Migration `0008` dropped and recreated the `account` table. Because foreign
+   keys were enforced, dropping the table cascaded via `ON DELETE CASCADE` into
+   `website-options` (and `website-data`), deleting their rows.
+
+3. **Why were foreign keys still enforced, when the migration explicitly ran
+   `PRAGMA foreign_keys=OFF`?**
+   In SQLite that pragma is a no-op inside a transaction, and drizzle runs
+   migrations inside a transaction. The connection was opened with
+   `foreign_keys = ON`, so enforcement was never actually disabled.
+
+4. **Why did the migration rebuild the entire `account` table instead of making
+   an additive change?**
+   drizzle-kit auto-generated a table-rebuild migration to add two foreign-key
+   columns, and that generated SQL was shipped without scrutinizing its
+   destructive `DROP TABLE` pattern (the additive `ALTER TABLE ADD COLUMN` form
+   was sufficient).
+
+5. **Why was the destructive migration not caught before release?**
+   There was no migration test that seeds representative data and verifies it
+   survives, no automated guard against destructive migration patterns, and no
+   pre-migration backup safety net. The interaction between the in-migration FK
+   pragma and drizzle's surrounding transaction was not understood by reviewers —
+   and is in fact a known upstream drizzle-orm bug
+   ([#5782](https://github.com/drizzle-team/drizzle-orm/issues/5782)) that is
+   silent specifically for `ON DELETE CASCADE` foreign keys.
+
+**Root cause statement:** A generated table-rebuild migration deleted data
+because its foreign-key guard was silently ineffective inside drizzle's
+transaction, and no test, review check, or backup existed to catch or mitigate
+it before release.
+
+---
+
+## Resolution
+
+1. **Made the migration non-destructive.** Migration `0008` was rewritten to add
+   the two columns directly, with no table rebuild and therefore no cascade:
+
+   ```sql
+   DROP TABLE `user-specified-website-options`;
+   ALTER TABLE `account` ADD `defaultFileTemplateId` text
+     REFERENCES `submission`(`id`) ON UPDATE no action ON DELETE set null;
+   ALTER TABLE `account` ADD `defaultMessageTemplateId` text
+     REFERENCES `submission`(`id`) ON UPDATE no action ON DELETE set null;
+   ```
+
+   Verified to preserve `website-options` and `website-data` while producing the
+   identical final schema. This protects users still on ≤4.0.39 who upgrade to a
+   later release. (Users who already ran the old `0008` will not re-run it, since
+   the migrator gates on the journal timestamp.)
+
+2. **Added self-healing recovery.** `SubmissionService.onModuleInit` now runs
+   `recreateMissingDefaultOptions()`, which restores the default (null-account)
+   website option for any submission missing it, so already-damaged databases
+   become structurally whole on next launch. (Note: this restores the option's
+   existence with default values; the specific values a user had typed are only
+   recoverable from a personal backup.)
+
+3. **Confirmed `website-data` self-heals.** Missing rows are recreated lazily by
+   `WebsiteDataManager.createOrLoadWebsiteData()` on website initialization. The
+   stored credentials themselves are unrecoverable, so users must re-authenticate.
+
+---
+
+## Remedies / Action Items
+
+| # | Action | Status |
+| --- | --- | --- |
+| 1 | Rewrite migration `0008` to be additive (no table rebuild). | ✅ Done |
+| 2 | Self-healing pass to recreate missing default website options on startup. | ✅ Done |
+| 3 | **Automatic pre-migration backups** — consistent `VACUUM INTO` snapshot taken only when migrations are pending, stored in a `backups/` subfolder, retaining the 5 most recent. | ✅ Done |
+| 4 | **Migration integrity tests** — seed representative data, run migrations as production does (FKs on, in a transaction), and assert data survives; plus a generic guard that fails for any future migration that destroys seeded data. | ✅ Done |
+| 5 | Prefer additive migrations; treat any generated `DROP TABLE` / table-rebuild as a red flag requiring explicit review. | ⏳ Process |
+| 6 | Document the FK-pragma trap: the in-SQL `PRAGMA foreign_keys=OFF` is ignored inside drizzle's transaction. If a rebuild is truly required, toggle FKs on the connection *outside* `migrate()`. | ⏳ Process |
+| 7 | Unit tests for the new recovery and backup logic. | ⏳ Planned |
+| 8 | User-facing restore path (list/restore a backup) instead of manual file swaps. | ⏳ Planned |
+| 9 | Decide whether to backfill the dropped `user-specified-website-options` (saved account defaults) into the new template model. | ⏳ Decision needed |
+| 10 | Add monitoring/alerting for unexpected mass row deletion so future incidents are detected automatically, not via user reports. | ⏳ Planned |
+| 11 | Apply the upstream-recommended workaround for [drizzle-orm#5782](https://github.com/drizzle-team/drizzle-orm/issues/5782): toggle `foreign_keys = OFF` on the raw connection **before** `migrate()` and restore it in a `finally`, so any future table-rebuild migration cannot silently cascade-delete. Revisit once the upstream fix (PR #5784) ships and drizzle is upgraded. | ⏳ Recommended |
+
+---
+
+## Lessons Learned
+
+- **Auto-generated migrations are not automatically safe.** A table rebuild that
+  reads as routine can be destructive in the presence of cascading foreign keys.
+- **Safety guards can be silently ineffective.** `PRAGMA foreign_keys=OFF` looked
+  like protection but did nothing inside a transaction. Guards must be verified,
+  not assumed.
+- **Backups are the only universal safety net.** Migration-specific fixes only
+  protect against known failure modes; a pre-migration snapshot protects against
+  the unknown ones too.
+- **Data-destroying changes need automated gates.** A seed-and-verify migration
+  test would have failed loudly before release.
+
+---
+
+## What Went Well / What Went Poorly
+
+**Went well:** Root cause was isolated and empirically confirmed quickly; the fix
+is additive and low-risk; durable safeguards (backups + tests) were added rather
+than just patching the symptom.
+
+**Went poorly:** The data loss was silent and shipped to production; it was caught
+by users rather than monitoring; the saved account-default data has no recovery
+path for already-upgraded users without a personal backup.
+
+---
+
+## References
+
+- [drizzle-team/drizzle-orm#5782](https://github.com/drizzle-team/drizzle-orm/issues/5782)
+  — SQLite table-rebuild migrations silently wipe child tables for any FK with
+  `ON DELETE CASCADE` (the upstream root-cause bug).
+- [drizzle-team/drizzle-orm#5784](https://github.com/drizzle-team/drizzle-orm/pull/5784)
+  — proposed upstream fix (hoist `PRAGMA foreign_keys` before `BEGIN`).
+- [drizzle-team/drizzle-orm#1813](https://github.com/drizzle-team/drizzle-orm/issues/1813)
+  and [#4089](https://github.com/drizzle-team/drizzle-orm/issues/4089) — the
+  long-standing *loud* (`NO ACTION`) variant of the same bug.
+- [SQLite: PRAGMA foreign_keys](https://www.sqlite.org/pragma.html#pragma_foreign_keys)
+  — "This pragma is a no-op within a transaction."
+- [SQLite: DROP TABLE](https://www.sqlite.org/lang_droptable.html) — implicit
+  `DELETE` and foreign-key actions on drop.
+- PostyBirb PR #919 (`54cc281`) — the change that introduced migration `0008`.

--- a/docs/postmortems/2026-06-24-default-website-options-data-loss.md
+++ b/docs/postmortems/2026-06-24-default-website-options-data-loss.md
@@ -37,6 +37,24 @@ records that pointed to it.
 default options can only be fully restored from a personal backup, but the app
 will no longer be in a broken state.
 
+### If you already upgraded to 4.0.40 (impacted)
+
+- Update to the next release. On first launch it automatically rebuilds the
+  missing default options.
+- Sign back in to each connected website (login data could not be recovered).
+- The exact values you had typed into default options can only be fully restored
+  from a personal backup taken before the 4.0.40 upgrade. If you have one, restore
+  it before launching the new version.
+
+### If you have not upgraded yet (not impacted)
+
+- Your data is intact. The bug only triggers during the 4.0.40 upgrade, which you
+  have not run.
+- Skip 4.0.40 and update directly to the next release. Its upgrade step is the
+  fixed, non-destructive version.
+- Optionally back up your database file first (`~\Documents\PostyBirb\data\database-production.sqlite`),
+  though the new version also creates an automatic pre-upgrade backup.
+
 ---
 
 ## Impact

--- a/libs/database/src/lib/database.ts
+++ b/libs/database/src/lib/database.ts
@@ -3,7 +3,9 @@ import { IsTestEnvironment } from '@postybirb/utils/common';
 import Database from 'better-sqlite3';
 import { BetterSQLite3Database, drizzle } from 'drizzle-orm/better-sqlite3';
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { existsSync } from 'fs';
 import { join } from 'path';
+import { backupBeforePendingMigrations } from './migration-backup';
 import { RepositoryRegistry } from './repositories/base/repository-registry';
 import * as schema from './schemas';
 
@@ -15,6 +17,36 @@ const migrationsFolder = IsTestEnvironment()
 let db: PostyBirbDatabaseType | undefined;
 
 /**
+ * Apply pending migrations with foreign-key enforcement disabled on the
+ * connection for the duration of the run.
+ *
+ * drizzle-kit emits `PRAGMA foreign_keys=OFF` inside table-rebuild migrations to
+ * stop cascades from firing while a table is dropped and recreated, but
+ * drizzle's migrator wraps every migration in a single transaction and SQLite
+ * treats `PRAGMA foreign_keys` as a no-op inside a transaction. The net effect
+ * is that a `DROP TABLE` during a rebuild silently cascade-deletes child rows
+ * (this is exactly how the 4.0.40 default-website-options data loss happened).
+ *
+ * Toggling the pragma here — outside (before) the migrator's transaction — is the
+ * only reliable way to neutralize it. `PRAGMA defer_foreign_keys` does NOT work:
+ * SQLite performs cascading actions immediately even when constraint checks are
+ * deferred.
+ *
+ * @see https://github.com/drizzle-team/drizzle-orm/issues/5782
+ */
+function runMigrations(
+  database: PostyBirbDatabaseType,
+  sqlite: Database.Database,
+) {
+  sqlite.pragma('foreign_keys = OFF');
+  try {
+    migrate(database, { migrationsFolder });
+  } finally {
+    sqlite.pragma('foreign_keys = ON');
+  }
+}
+
+/**
  * Get the database instance
  */
 export function getDatabase() {
@@ -23,16 +55,23 @@ export function getDatabase() {
       const sqlite = new Database(':memory:');
       sqlite.pragma('foreign_keys = ON');
       db = drizzle(sqlite, { schema });
-      migrate(db, { migrationsFolder });
+      runMigrations(db, sqlite);
     } else {
       const path = join(
         PostyBirbDirectories.DATA_DIRECTORY,
         `database-${process.env.POSTYBIRB_ENV}.sqlite`,
       );
+      const databaseExistedBefore = existsSync(path);
       const sqlite = new Database(path);
       sqlite.pragma('foreign_keys = ON');
       db = drizzle(sqlite, { schema });
-      migrate(db, { migrationsFolder });
+      // Snapshot existing user data before applying any pending migrations so a
+      // destructive migration can always be recovered. Skipped for brand-new
+      // databases, which have nothing to lose.
+      if (databaseExistedBefore) {
+        backupBeforePendingMigrations(sqlite, path, migrationsFolder);
+      }
+      runMigrations(db, sqlite);
     }
   }
 

--- a/libs/database/src/lib/migration-backup.ts
+++ b/libs/database/src/lib/migration-backup.ts
@@ -1,0 +1,150 @@
+import { Logger } from '@postybirb/logger';
+import type Database from 'better-sqlite3';
+import { readMigrationFiles } from 'drizzle-orm/migrator';
+import { mkdirSync, readdirSync, rmSync, statSync } from 'fs';
+import { basename, dirname, join } from 'path';
+
+const logger = Logger('DatabaseBackup');
+
+/**
+ * Number of timestamped pre-migration backups to retain. Older backups beyond
+ * this count are pruned after each successful backup.
+ */
+const MAX_BACKUPS = 5;
+
+/**
+ * Name of the subfolder (alongside the database file) that holds pre-migration
+ * backups.
+ */
+const BACKUP_DIR_NAME = 'backups';
+
+/**
+ * Drizzle's migration bookkeeping table. Mirrors the default used by
+ * `drizzle-orm/better-sqlite3/migrator`.
+ */
+const MIGRATIONS_TABLE = '__drizzle_migrations';
+
+/**
+ * Creates a timestamped, consistent backup of the database file when one or
+ * more migrations are pending.
+ *
+ * This is a safety net against migrations that unexpectedly destroy data (for
+ * example a table rebuild that triggers `ON DELETE CASCADE`). The backup is
+ * taken before {@link migrate} runs, so a damaged migration can always be
+ * recovered from the most recent snapshot.
+ *
+ * Backup failures never block startup — the migration remains the source of
+ * truth — but they are logged loudly so they can be investigated.
+ *
+ * @param sqlite - The opened better-sqlite3 connection.
+ * @param databasePath - Absolute path to the database file being backed up.
+ * @param migrationsFolder - Folder containing the drizzle migrations.
+ */
+export function backupBeforePendingMigrations(
+  sqlite: Database.Database,
+  databasePath: string,
+  migrationsFolder: string,
+): void {
+  try {
+    if (!hasPendingMigrations(sqlite, migrationsFolder)) {
+      return;
+    }
+
+    const backupPath = createBackup(sqlite, databasePath);
+    logger
+      .withMetadata({ backupPath })
+      .info('Created pre-migration database backup');
+
+    pruneOldBackups(databasePath);
+  } catch (err) {
+    logger
+      .withError(err)
+      .error('Failed to create pre-migration database backup');
+  }
+}
+
+/**
+ * Determines whether any migration newer than the last-applied one exists.
+ */
+function hasPendingMigrations(
+  sqlite: Database.Database,
+  migrationsFolder: string,
+): boolean {
+  const migrations = readMigrationFiles({ migrationsFolder });
+  if (migrations.length === 0) {
+    return false;
+  }
+
+  const maxFolderMillis = migrations.reduce(
+    (max, migration) => Math.max(max, migration.folderMillis),
+    0,
+  );
+
+  return maxFolderMillis > getLastAppliedFolderMillis(sqlite);
+}
+
+/**
+ * Reads the `folderMillis` of the most recently applied migration, or 0 when no
+ * migrations have been applied (the bookkeeping table may not exist yet).
+ */
+function getLastAppliedFolderMillis(sqlite: Database.Database): number {
+  try {
+    const row = sqlite
+      .prepare(
+        `SELECT created_at FROM "${MIGRATIONS_TABLE}" ORDER BY created_at DESC LIMIT 1`,
+      )
+      .get() as { created_at: number } | undefined;
+    return Number(row?.created_at ?? 0);
+  } catch {
+    // Table does not exist yet => nothing has been applied.
+    return 0;
+  }
+}
+
+/**
+ * Returns the directory that holds pre-migration backups, creating it if needed.
+ */
+function getBackupDir(databasePath: string): string {
+  const backupDir = join(dirname(databasePath), BACKUP_DIR_NAME);
+  mkdirSync(backupDir, { recursive: true });
+  return backupDir;
+}
+
+/**
+ * Writes a consistent standalone copy of the database using `VACUUM INTO`,
+ * which is safe regardless of journal mode and does not require the connection
+ * to be idle. Returns the backup file path.
+ */
+function createBackup(
+  sqlite: Database.Database,
+  databasePath: string,
+): string {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const backupPath = join(
+    getBackupDir(databasePath),
+    `${basename(databasePath)}.backup-${timestamp}.sqlite`,
+  );
+  // Escape single quotes for the SQL string literal (paths are app-controlled,
+  // but this keeps it robust).
+  const escapedPath = backupPath.replace(/'/g, "''");
+  sqlite.exec(`VACUUM INTO '${escapedPath}'`);
+  return backupPath;
+}
+
+/**
+ * Deletes the oldest pre-migration backups, keeping the {@link MAX_BACKUPS}
+ * most recent.
+ */
+function pruneOldBackups(databasePath: string): void {
+  const backupDir = getBackupDir(databasePath);
+  const prefix = `${basename(databasePath)}.backup-`;
+
+  const backups = readdirSync(backupDir)
+    .filter((name) => name.startsWith(prefix) && name.endsWith('.sqlite'))
+    .map((name) => join(backupDir, name))
+    .sort((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs);
+
+  for (const stale of backups.slice(MAX_BACKUPS)) {
+    rmSync(stale, { force: true });
+  }
+}

--- a/libs/database/src/lib/migration-integrity.spec.ts
+++ b/libs/database/src/lib/migration-integrity.spec.ts
@@ -167,6 +167,7 @@ describe('migration integrity', () => {
     applyMigrations(sqlite, migrations.slice(0, targetIndex));
     seedAccountGraph(sqlite);
 
+    expect(countRows(sqlite, 'account')).toBe(1);
     expect(countRows(sqlite, 'website-options')).toBe(1);
     expect(countRows(sqlite, 'website-data')).toBe(1);
 
@@ -174,6 +175,7 @@ describe('migration integrity', () => {
     applyMigrations(sqlite, migrations.slice(targetIndex));
 
     // Data must survive the upgrade.
+    expect(countRows(sqlite, 'account')).toBe(1);
     expect(countRows(sqlite, 'website-options')).toBe(1);
     expect(countRows(sqlite, 'website-data')).toBe(1);
 

--- a/libs/database/src/lib/migration-integrity.spec.ts
+++ b/libs/database/src/lib/migration-integrity.spec.ts
@@ -1,0 +1,221 @@
+import Database from 'better-sqlite3';
+import { readMigrationFiles } from 'drizzle-orm/migrator';
+import { join } from 'path';
+
+/**
+ * Migration integrity guard.
+ *
+ * These tests run the real drizzle migrations against a database seeded with
+ * representative data and assert that applying migrations never destroys it.
+ *
+ * They exist because a table-rebuild migration (`DROP TABLE ... RENAME`) ran
+ * with foreign keys enabled and cascade-deleted `website-options` and
+ * `website-data` rows. The in-migration `PRAGMA foreign_keys=OFF` is a no-op
+ * because drizzle wraps migrations in a transaction. The generic guard below
+ * will fail for any future migration that reintroduces this class of bug.
+ */
+
+type MigrationFile = ReturnType<typeof readMigrationFiles>[number];
+
+type ColumnInfo = {
+  name: string;
+  type: string;
+  notnull: number;
+  pk: number;
+};
+
+const migrationsFolder = join(
+  __dirname.split('libs')[0],
+  'apps',
+  'postybirb',
+  'src',
+  'migrations',
+);
+
+function loadMigrations(): MigrationFile[] {
+  return readMigrationFiles({ migrationsFolder }).sort(
+    (a, b) => a.folderMillis - b.folderMillis,
+  );
+}
+
+/**
+ * Applies a set of migrations exactly as production does: inside a single
+ * transaction with foreign keys enabled.
+ */
+function applyMigrations(
+  sqlite: Database.Database,
+  migrations: MigrationFile[],
+): void {
+  sqlite.exec('BEGIN');
+  try {
+    for (const migration of migrations) {
+      for (const statement of migration.sql) {
+        sqlite.exec(statement);
+      }
+    }
+    sqlite.exec('COMMIT');
+  } catch (err) {
+    sqlite.exec('ROLLBACK');
+    throw err;
+  }
+}
+
+function defaultForType(type: string): string | number {
+  const upper = type.toUpperCase();
+  if (
+    upper.includes('INT') ||
+    upper.includes('REAL') ||
+    upper.includes('FLOA') ||
+    upper.includes('DOUB') ||
+    upper.includes('NUM')
+  ) {
+    return 0;
+  }
+  return 'x';
+}
+
+function tableExists(sqlite: Database.Database, table: string): boolean {
+  return (
+    sqlite
+      .prepare(
+        `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?`,
+      )
+      .get(table) !== undefined
+  );
+}
+
+function countRows(sqlite: Database.Database, table: string): number {
+  return (
+    sqlite.prepare(`SELECT COUNT(*) AS c FROM "${table}"`).get() as {
+      c: number;
+    }
+  ).c;
+}
+
+/**
+ * Inserts a single row into `table`, auto-filling NOT NULL / primary key columns
+ * with type-appropriate placeholders. `overrides` provides explicit values
+ * (e.g. ids and foreign keys); pass `undefined` to skip an optional column.
+ */
+function seedRow(
+  sqlite: Database.Database,
+  table: string,
+  overrides: Record<string, unknown> = {},
+): void {
+  const columns = sqlite
+    .prepare(`PRAGMA table_info("${table}")`)
+    .all() as ColumnInfo[];
+
+  const values: Record<string, unknown> = {};
+  for (const column of columns) {
+    if (Object.prototype.hasOwnProperty.call(overrides, column.name)) {
+      if (overrides[column.name] === undefined) {
+        continue;
+      }
+      values[column.name] = overrides[column.name];
+    } else if (column.pk || column.notnull) {
+      values[column.name] = defaultForType(column.type);
+    }
+  }
+
+  const names = Object.keys(values);
+  const placeholders = names.map(() => '?').join(', ');
+  sqlite
+    .prepare(
+      `INSERT INTO "${table}" (${names
+        .map((n) => `"${n}"`)
+        .join(', ')}) VALUES (${placeholders})`,
+    )
+    .run(...names.map((n) => values[n]));
+}
+
+/**
+ * Seeds the account-rooted tables most affected by cascade deletes.
+ * Requires that the corresponding tables already exist at the current schema.
+ */
+function seedAccountGraph(sqlite: Database.Database): void {
+  seedRow(sqlite, 'account', { id: 'acc1' });
+  seedRow(sqlite, 'submission', { id: 'sub1' });
+  seedRow(sqlite, 'website-options', {
+    id: 'wo1',
+    accountId: 'acc1',
+    submissionId: 'sub1',
+  });
+  if (tableExists(sqlite, 'website-data')) {
+    seedRow(sqlite, 'website-data', { id: 'acc1' });
+  }
+}
+
+function newDatabase(): Database.Database {
+  const sqlite = new Database(':memory:');
+  sqlite.pragma('foreign_keys = ON');
+  return sqlite;
+}
+
+describe('migration integrity', () => {
+  it('preserves account-rooted data across the full migration chain', () => {
+    const sqlite = newDatabase();
+    const migrations = loadMigrations();
+
+    // Find the account-template refactor migration (the one that introduced the
+    // regression) and split the chain just before it to emulate an upgrade.
+    const targetIndex = migrations.findIndex((m) =>
+      m.sql.join('\n').includes('defaultFileTemplateId'),
+    );
+    expect(targetIndex).toBeGreaterThan(0);
+
+    applyMigrations(sqlite, migrations.slice(0, targetIndex));
+    seedAccountGraph(sqlite);
+
+    expect(countRows(sqlite, 'website-options')).toBe(1);
+    expect(countRows(sqlite, 'website-data')).toBe(1);
+
+    // Apply the remaining (pending) migrations as production would.
+    applyMigrations(sqlite, migrations.slice(targetIndex));
+
+    // Data must survive the upgrade.
+    expect(countRows(sqlite, 'website-options')).toBe(1);
+    expect(countRows(sqlite, 'website-data')).toBe(1);
+
+    // And the new columns must exist.
+    const accountColumns = (
+      sqlite.prepare(`PRAGMA table_info("account")`).all() as ColumnInfo[]
+    ).map((c) => c.name);
+    expect(accountColumns).toEqual(
+      expect.arrayContaining([
+        'defaultFileTemplateId',
+        'defaultMessageTemplateId',
+      ]),
+    );
+
+    sqlite.close();
+  });
+
+  it('does not destroy seeded data when applying the latest migration', () => {
+    const sqlite = newDatabase();
+    const migrations = loadMigrations();
+    expect(migrations.length).toBeGreaterThan(1);
+
+    const allButLast = migrations.slice(0, -1);
+    const last = migrations[migrations.length - 1];
+
+    applyMigrations(sqlite, allButLast);
+    seedAccountGraph(sqlite);
+
+    const critical = ['account', 'submission', 'website-options', 'website-data'];
+    const before = critical
+      .filter((table) => tableExists(sqlite, table))
+      .map((table) => [table, countRows(sqlite, table)] as const);
+
+    applyMigrations(sqlite, [last]);
+
+    for (const [table, count] of before) {
+      // A table that still exists after the latest migration must keep its rows.
+      if (tableExists(sqlite, table)) {
+        expect(countRows(sqlite, table)).toBe(count);
+      }
+    }
+
+    sqlite.close();
+  });
+});


### PR DESCRIPTION
Migration 0008 (account-template refactor) rebuilt the `account` table while
foreign keys were enabled. drizzle wraps migrations in a single transaction, and
SQLite treats `PRAGMA foreign_keys=OFF` as a no-op inside a transaction, so
`DROP TABLE account` silently cascade-deleted every `website-options` and
`website-data` row. Users who upgraded to 4.0.40 lost their default (null-account)
posting options and were signed out of all connected websites. This is the known
upstream bug drizzle-team/drizzle-orm#5782.

Fixes and safeguards:

- Rewrite migration 0008 to be additive (ALTER TABLE ADD COLUMN) instead of a
  destructive table rebuild; end-state schema is unchanged.
- Disable foreign_keys on the raw connection before migrate() and restore it in a
  finally, so no future table-rebuild migration can silently cascade-delete child
  rows (upstream-recommended workaround for #5782).
- Add a self-healing startup pass (recreateMissingDefaultOptions) that rebuilds
  missing default submission options for already-impacted users.
- Add automatic pre-migration database backups (VACUUM INTO, retain 5) so any
  future destructive migration is recoverable.
- Add a migration-integrity test harness that seeds account/website-options/
  website-data and fails for any migration that destroys existing data.
- Add a postmortem documenting root cause, impact, and remedies.

Notes:
- Already-migrated 4.0.40 users won't re-run 0008 (gated by journal folderMillis);
  the recovery pass and backups cover them going forward.
- Connected accounts must be signed in again (login data could not be recovered).