### PR TITLE
fix: keep app alive on window-all-closed to stop headless crash loop

### DIFF
--- a/apps/postybirb/src/app/app.ts
+++ b/apps/postybirb/src/app/app.ts
@@ -1,4 +1,3 @@
-import { INestApplication } from '@nestjs/common';
 import { app } from 'electron';
 import { installAppSecurity } from './main-process/security';
 import { TrayManager } from './main-process/tray';
@@ -13,8 +12,6 @@ export default class PostyBirbApp {
   private readonly windowManager = new WindowManager();
 
   private tray: TrayManager | null = null;
-
-  constructor(private readonly nestApp: INestApplication) {}
 
   /**
    * Install security policies, create the main window and tray, and register
@@ -35,8 +32,8 @@ export default class PostyBirbApp {
   }
 
   private registerLifecycleEvents(): void {
-    // Keep PostyBirb running in the system tray after the last window closes.
-    app.on('window-all-closed', () => {});
+    // The `window-all-closed` override is registered globally in main.ts so it
+    // applies in both GUI and headless modes (see the crash-loop note there).
 
     // macOS: re-show the window when the dock icon is clicked.
     app.on('activate', () => {
@@ -49,17 +46,5 @@ export default class PostyBirbApp {
         this.windowManager.show();
       }
     });
-
-    app.on('quit', () => {
-      this.shutdown();
-    });
-  }
-
-  private async shutdown(): Promise<void> {
-    await this.nestApp.close().catch((error) => {
-      // Ignore errors during shutdown
-      console.error('Error during shutdown:', error);
-    });
-    process.exit();
   }
 }

--- a/apps/postybirb/src/app/main-process/startup.ts
+++ b/apps/postybirb/src/app/main-process/startup.ts
@@ -2,9 +2,9 @@ import { INestApplication } from '@nestjs/common';
 import { PostyBirbDirectories } from '@postybirb/fs';
 import { flushAppInsights, Logger, trackException } from '@postybirb/logger';
 import {
-    PostyBirbEnvConfig,
-    RemoteConfigManager,
-    toError,
+  PostyBirbEnvConfig,
+  RemoteConfigManager,
+  toError,
 } from '@postybirb/utils/common';
 import { app } from 'electron';
 import { environment } from '../../environments/environment';
@@ -125,5 +125,57 @@ export function quitOnStartupFailure(error: unknown): void {
 
   flushAppInsights().finally(() => {
     app.quit();
+  });
+}
+
+/**
+ * Wire a single graceful-shutdown path for every launch mode. The embedded
+ * NestJS server must close cleanly — flushing the database and terminating its
+ * worker processes — however the quit is triggered:
+ *  - GUI: the tray "Quit" action or Cmd-Q drive `app.quit()`.
+ *  - Terminal (GUI or headless): Ctrl-C sends SIGINT and `docker stop` sends
+ *    SIGTERM. Electron does not turn these signals into a quit on its own, so
+ *    without this the process would be killed abruptly with no cleanup.
+ *
+ * Registered once, after the server has bootstrapped, so `nestApp` is always
+ * available when a quit is requested.
+ */
+export function registerGracefulShutdown(nestApp: INestApplication): void {
+  let isShuttingDown = false;
+
+  const closeAndExit = (): void => {
+    if (isShuttingDown) {
+      return;
+    }
+    isShuttingDown = true;
+
+    // Guard against a hung close leaving the container running indefinitely.
+    const forceExitTimer = setTimeout(() => app.exit(0), 5_000);
+    forceExitTimer.unref();
+
+    nestApp
+      .close()
+      .catch((error) => {
+        logger
+          .withError(toError(error))
+          .error('Error while closing the embedded server during shutdown.');
+      })
+      .finally(() => {
+        clearTimeout(forceExitTimer);
+        app.exit(0);
+      });
+  };
+
+  // Translate container/terminal termination signals into an Electron quit.
+  process.once('SIGTERM', () => app.quit());
+  process.once('SIGINT', () => app.quit());
+
+  // Defer the actual quit until the embedded server has closed cleanly.
+  app.on('before-quit', (event) => {
+    if (isShuttingDown) {
+      return;
+    }
+    event.preventDefault();
+    closeAndExit();
   });
 }

--- a/apps/postybirb/src/main.ts
+++ b/apps/postybirb/src/main.ts
@@ -22,11 +22,13 @@ import {
   registerProcessErrorHandlers,
 } from './app/main-process/diagnostics';
 import { startupLoader } from './app/main-process/loader';
+import { installAppSecurity } from './app/main-process/security';
 import {
   bootstrapWithTimeout,
   injectProcessEnvironment,
   logStartupBanner,
   quitOnStartupFailure,
+  registerGracefulShutdown,
 } from './app/main-process/startup';
 import { environment } from './environments/environment';
 
@@ -81,7 +83,17 @@ async function start(): Promise<void> {
   try {
     const nestApp = await bootstrapWithTimeout(bootstrapClientServer);
 
+    // A single graceful-shutdown path for every launch mode (GUI, terminal,
+    // headless/Docker). Registered here — after bootstrap — so the embedded
+    // server is always available to close cleanly when a quit is requested.
+    registerGracefulShutdown(nestApp);
+
     if (PostyBirbEnvConfig.headless) {
+      // Background login/scraper flows still open hidden BrowserWindows in
+      // headless mode, so apply the same security policies the GUI path applies
+      // via PostyBirbApp.
+      installAppSecurity();
+
       // eslint-disable-next-line no-console
       console.log('[PostyBirb] Running in headless mode (no UI)');
       return;
@@ -91,7 +103,7 @@ async function start(): Promise<void> {
     // can synchronously read app metadata as it loads.
     bootstrapElectronEvents();
 
-    const postyBirb = new PostyBirbApp(nestApp);
+    const postyBirb = new PostyBirbApp();
     postyBirb.start();
   } catch (error) {
     quitOnStartupFailure(error);
@@ -112,6 +124,17 @@ app
   .catch((error) => {
     quitOnStartupFailure(error);
   });
+
+// Keep the application alive when the last window closes. Electron's default
+// behavior quits the app once the open-window count reaches zero. In GUI mode
+// this keeps PostyBirb running in the system tray; in headless mode it is
+// essential — background login/scraper flows briefly open and close hidden
+// BrowserWindows, and the default quit-on-zero-windows behavior would tear down
+// the process (killing the NestJS server and its child processes), producing an
+// infinite crash/restart loop under Docker.
+app.on('window-all-closed', () => {
+  // Intentionally empty: overrides Electron's default quit-on-all-closed.
+});
 
 app.on('before-quit', () => {
   startupLoader.hide('before-quit');


### PR DESCRIPTION
In headless mode, start() returned before PostyBirbApp.start(), so registerLifecycleEvents() never ran and the `window-all-closed` override was never registered. Background login/scraper flows briefly open and destroy hidden BrowserWindows; when the open-window count hit zero, Electron's default behavior quit the app, sending SIGTERM to the sharp utility process (exitCode 15) and exiting the container, which Docker then restarted in an infinite loop.

- Register `window-all-closed` at the top level of main.ts so it applies in both GUI and headless modes.
- Apply installAppSecurity() in headless mode so the hidden windows used by login/scraper flows get the same popup/permission/certificate hardening as the GUI.
- Add one graceful-shutdown path (registerGracefulShutdown) for all launch modes: translate SIGTERM/SIGINT into app.quit() and close the embedded NestJS server on before-quit, with a force-exit guard. Removes the old app-only quit handler so there is a single path.

Fixes #928