### PR TITLE
fix: color selection

### DIFF
--- a/apps/postybirb-ui/src/components/shared/description-editor/components/bubble-toolbar.tsx
+++ b/apps/postybirb-ui/src/components/shared/description-editor/components/bubble-toolbar.tsx
@@ -1,22 +1,13 @@
 /* eslint-disable lingui/no-unlocalized-strings */
+import { ActionIcon, Group, Tooltip } from '@mantine/core';
 import {
-    ActionIcon,
-    Button,
-    ColorInput,
-    Group,
-    Modal,
-    Tooltip,
-} from '@mantine/core';
-import { useDisclosure } from '@mantine/hooks';
-import {
-    IconBold,
-    IconItalic,
-    IconStrikethrough,
-    IconUnderline,
+  IconBold,
+  IconItalic,
+  IconStrikethrough,
+  IconUnderline,
 } from '@tabler/icons-react';
 import type { Editor } from '@tiptap/react';
 import { BubbleMenu } from '@tiptap/react/menus';
-import { useCallback, useRef, useState } from 'react';
 
 interface BubbleToolbarProps {
   editor: Editor;
@@ -27,172 +18,59 @@ interface BubbleToolbarProps {
  * Shows compact inline formatting options.
  */
 export function BubbleToolbar({ editor }: BubbleToolbarProps) {
-  const [colorOpened, { open: openColor, close: closeColor }] =
-    useDisclosure(false);
-  // Selection captured when the color picker opened. Applied to this range
-  // so focus moving to the modal does not result in an empty selection.
-  const savedRangeRef = useRef<{ from: number; to: number } | null>(null);
-  // Local state for the modal's color input so the user can scrub through
-  // the gradient without each intermediate value being committed to history.
-  const [pendingColor, setPendingColor] = useState<string>('');
-
-  const handleOpenColor = useCallback(() => {
-    const { from, to } = editor.state.selection;
-    if (from === to) return; // nothing selected
-    savedRangeRef.current = { from, to };
-    const current =
-      (editor.getAttributes('textStyle')?.color as string | undefined) || '';
-    setPendingColor(current);
-    openColor();
-  }, [editor, openColor]);
-
-  const applyColor = useCallback(
-    (color: string) => {
-      const range = savedRangeRef.current;
-      if (!range) return;
-      const chain = editor.chain().setTextSelection(range);
-      if (color) {
-        chain.setColor(color).run();
-      } else {
-        chain.unsetColor().run();
-      }
-    },
-    [editor],
-  );
-
-  const handleClose = useCallback(() => {
-    const range = savedRangeRef.current;
-    closeColor();
-    savedRangeRef.current = null;
-    if (range) {
-      editor.chain().focus().setTextSelection(range).run();
-    } else {
-      editor.commands.focus();
-    }
-  }, [editor, closeColor]);
-
-  const handleConfirm = useCallback(() => {
-    applyColor(pendingColor);
-    handleClose();
-  }, [applyColor, pendingColor, handleClose]);
-
-  const handleClear = useCallback(() => {
-    applyColor('');
-    handleClose();
-  }, [applyColor, handleClose]);
-
-  const currentColor = editor.getAttributes('textStyle')?.color || '';
-
   return (
-    <>
-      <BubbleMenu
-        editor={editor}
-        options={{
-          placement: 'top',
-          offset: 8,
-          flip: true,
-          shift: true,
-          inline: true,
-        }}
-      >
-        <div className="pb-bubble-menu" role="toolbar">
-          <Group
-            gap={2}
-            p={4}
-            style={{
-              background: 'var(--mantine-color-body)',
-              border: '1px solid var(--mantine-color-default-border)',
-              borderRadius: 'var(--mantine-radius-md)',
-              boxShadow: 'var(--mantine-shadow-md)',
-            }}
-          >
-            <BubbleButton
-              icon={<IconBold size={14} />}
-              label="Bold"
-              isActive={editor.isActive('bold')}
-              onClick={() => editor.chain().focus().toggleBold().run()}
-            />
-            <BubbleButton
-              icon={<IconItalic size={14} />}
-              label="Italic"
-              isActive={editor.isActive('italic')}
-              onClick={() => editor.chain().focus().toggleItalic().run()}
-            />
-            <BubbleButton
-              icon={<IconUnderline size={14} />}
-              label="Underline"
-              isActive={editor.isActive('underline')}
-              onClick={() => editor.chain().focus().toggleUnderline().run()}
-            />
-            <BubbleButton
-              icon={<IconStrikethrough size={14} />}
-              label="Strike"
-              isActive={editor.isActive('strike')}
-              onClick={() => editor.chain().focus().toggleStrike().run()}
-            />
-            <Tooltip label="Text Color" withArrow openDelay={300}>
-              <ActionIcon
-                size="xs"
-                variant="subtle"
-                color="gray"
-                style={currentColor ? { color: currentColor } : undefined}
-                // Capture the selection on mousedown so that the click doesn't
-                // collapse it before we can save the range.
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  handleOpenColor();
-                }}
-              >
-                <span style={{ fontWeight: 'bold', fontSize: '12px' }}>A</span>
-              </ActionIcon>
-            </Tooltip>
-          </Group>
-        </div>
-      </BubbleMenu>
-      <Modal
-        opened={colorOpened}
-        onClose={handleClose}
-        title="Text Color"
-        size="sm"
-        centered
-        zIndex={1000}
-      >
-        <ColorInput
-          value={pendingColor}
-          onChange={setPendingColor}
-          format="hex"
-          popoverProps={{ zIndex: 1100, withinPortal: true }}
-          swatches={[
-            '#000000',
-            '#868e96',
-            '#fa5252',
-            '#e64980',
-            '#be4bdb',
-            '#7950f2',
-            '#4c6ef5',
-            '#228be6',
-            '#15aabf',
-            '#12b886',
-            '#40c057',
-            '#82c91e',
-            '#fab005',
-            '#fd7e14',
-          ]}
-          swatchesPerRow={7}
-        />
-        <Group justify="flex-end" mt="md" gap="xs">
-          <Button variant="subtle" color="red" onClick={handleClear} size="xs">
-            Clear
-          </Button>
-          <Button variant="filled" onClick={handleConfirm} size="xs">
-            Apply
-          </Button>
+    <BubbleMenu
+      editor={editor}
+      options={{
+        placement: 'top',
+        offset: 8,
+        flip: true,
+        shift: true,
+        inline: true,
+      }}
+    >
+      <div className="pb-bubble-menu" role="toolbar">
+        <Group
+          gap={2}
+          p={4}
+          style={{
+            background: 'var(--mantine-color-body)',
+            border: '1px solid var(--mantine-color-default-border)',
+            borderRadius: 'var(--mantine-radius-md)',
+            boxShadow: 'var(--mantine-shadow-md)',
+          }}
+        >
+          <BubbleButton
+            icon={<IconBold size={14} />}
+            label="Bold"
+            isActive={editor.isActive('bold')}
+            onClick={() => editor.chain().focus().toggleBold().run()}
+          />
+          <BubbleButton
+            icon={<IconItalic size={14} />}
+            label="Italic"
+            isActive={editor.isActive('italic')}
+            onClick={() => editor.chain().focus().toggleItalic().run()}
+          />
+          <BubbleButton
+            icon={<IconUnderline size={14} />}
+            label="Underline"
+            isActive={editor.isActive('underline')}
+            onClick={() => editor.chain().focus().toggleUnderline().run()}
+          />
+          <BubbleButton
+            icon={<IconStrikethrough size={14} />}
+            label="Strike"
+            isActive={editor.isActive('strike')}
+            onClick={() => editor.chain().focus().toggleStrike().run()}
+          />
         </Group>
-      </Modal>
-    </>
+      </div>
+    </BubbleMenu>
   );
 }
 
+/** Helper button for the bubble menu */
 function BubbleButton({
   icon,
   label,

--- a/apps/postybirb-ui/src/components/shared/description-editor/components/description-toolbar.tsx
+++ b/apps/postybirb-ui/src/components/shared/description-editor/components/description-toolbar.tsx
@@ -4,12 +4,13 @@ import {
   ActionIcon,
   Button,
   CloseButton,
-  ColorInput,
+  ColorPicker,
   Divider,
   Group,
   Modal,
   Popover,
   Stack,
+  Text,
   TextInput,
   Tooltip,
 } from '@mantine/core';
@@ -21,6 +22,8 @@ import {
   IconArrowBackUp,
   IconArrowForwardUp,
   IconBold,
+  IconColorPicker,
+  IconEraser,
   IconEye,
   IconH1,
   IconH2,
@@ -38,7 +41,7 @@ import {
   IconUnderline,
 } from '@tabler/icons-react';
 import type { Editor } from '@tiptap/react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 interface DescriptionToolbarProps {
   editor: Editor | null;
@@ -357,23 +360,86 @@ function TextColorButton({ editor }: { editor: Editor }) {
   const currentColor = editor.getAttributes('textStyle')?.color || '';
 
   const handleChange = useCallback(
-    (color: string) => {
-      if (color) {
-        editor.chain().focus().setColor(color).run();
+    (newColor: string) => {
+      setColor(newColor);
+      const range = savedRangeRef.current;
+      let chain = editor.chain();
+      if (range) {
+        chain = chain.setTextSelection(range);
+      }
+      if (newColor && newColor.trim() !== '') {
+        chain.setColor(newColor).run();
       } else {
-        editor.chain().focus().unsetColor().run();
+        chain.unsetColor().run();
       }
     },
     [editor],
   );
 
+  const [color, setColor] = useState(currentColor);
+  const [isPicking, setIsPicking] = useState(false);
+  const savedRangeRef = useRef<{ from: number; to: number } | null>(null);
+
+  // Sync local state when editor color changes externally
+  useEffect(() => {
+    setColor(currentColor);
+  }, [currentColor]);
+
+  // Save selection when popover opens
+  useEffect(() => {
+    if (opened) {
+      const { from, to } = editor.state.selection;
+      if (from !== to) {
+        savedRangeRef.current = { from, to };
+      } else {
+        savedRangeRef.current = null;
+      }
+    }
+  }, [opened, editor]);
+
+  const handleReset = useCallback(() => {
+    // unsetColor
+    handleChange('');
+  }, [handleChange]);
+
+  const handleEyeDropper = useCallback(async () => {
+    if (!('EyeDropper' in window)) return;
+    try {
+      setIsPicking(true);
+      const eyeDropper = new (
+        window as unknown as {
+          EyeDropper: { new (): { open(): Promise<{ sRGBHex: string }> } };
+        }
+      ).EyeDropper();
+      const result = await eyeDropper.open();
+      const hexColor = result.sRGBHex;
+      if (hexColor) {
+        handleChange(hexColor);
+      }
+    } catch {
+      // user cancelled
+    } finally {
+      setIsPicking(false);
+    }
+  }, [handleChange]);
+
+  const handleClose = useCallback(() => {
+    close();
+    if (savedRangeRef.current) {
+      editor.chain().focus().setTextSelection(savedRangeRef.current).run();
+      savedRangeRef.current = null;
+    } else {
+      editor.commands.focus();
+    }
+  }, [close, editor]);
+
   return (
     <Popover
       opened={opened}
-      onClose={close}
-      width={220}
+      onClose={handleClose}
+      width={280}
       shadow="md"
-      position="bottom"
+      position="top"
     >
       <Popover.Target>
         <Tooltip label="Text Color" withArrow openDelay={500}>
@@ -390,26 +456,19 @@ function TextColorButton({ editor }: { editor: Editor }) {
       </Popover.Target>
       <Popover.Dropdown
         onKeyDown={(e: React.KeyboardEvent) => {
-          if (e.key === 'Escape') {
-            close();
-            editor.commands.focus();
-          }
+          if (e.key === 'Escape') handleClose();
         }}
       >
         <Stack gap={4}>
-          <Group justify="flex-end">
-            <CloseButton
-              size="xs"
-              onClick={() => {
-                close();
-                editor.commands.focus();
-              }}
-            />
+          <Group justify="space-between">
+            <Text>Pick Color</Text>
+            <CloseButton size="sm" onClick={handleClose} />
           </Group>
-          <ColorInput
-            size="xs"
-            value={currentColor}
+
+          <ColorPicker
+            value={color}
             onChange={handleChange}
+            format="hex"
             swatches={[
               '#000000',
               '#868e96',
@@ -428,6 +487,41 @@ function TextColorButton({ editor }: { editor: Editor }) {
             ]}
             swatchesPerRow={7}
           />
+
+          <Group gap={4} align="center">
+            <TextInput
+              size="xs"
+              style={{ flex: 1 }}
+              value={color}
+              onChange={(e) => handleChange(e.currentTarget.value)}
+              placeholder="Enter hex color (e.g. #ff0000)"
+            />
+            {'EyeDropper' in window && (
+              <Tooltip label="Pick color from screen" withArrow openDelay={500}>
+                <ActionIcon
+                  size="sm"
+                  variant="subtle"
+                  color="gray"
+                  onClick={handleEyeDropper}
+                  disabled={isPicking}
+                  aria-label="Pick color from screen"
+                >
+                  <IconColorPicker size={16} />
+                </ActionIcon>
+              </Tooltip>
+            )}
+            <Tooltip label="Reset color" withArrow openDelay={500}>
+              <ActionIcon
+                size="xs"
+                variant="subtle"
+                color="red"
+                onClick={handleReset}
+                aria-label="Reset color"
+              >
+                <IconEraser size={16} />
+              </ActionIcon>
+            </Tooltip>
+          </Group>
         </Stack>
       </Popover.Dropdown>
     </Popover>

--- a/apps/postybirb-ui/src/components/shared/description-editor/description-editor.tsx
+++ b/apps/postybirb-ui/src/components/shared/description-editor/description-editor.tsx
@@ -20,7 +20,6 @@ import {
 import { AnyExtension, Extension } from '@tiptap/core';
 import Bold from '@tiptap/extension-bold';
 import BulletList from '@tiptap/extension-bullet-list';
-
 import Color from '@tiptap/extension-color';
 import Document from '@tiptap/extension-document';
 import Dropcursor from '@tiptap/extension-dropcursor';
@@ -38,8 +37,10 @@ import Placeholder from '@tiptap/extension-placeholder';
 import Strike from '@tiptap/extension-strike';
 import TextNode from '@tiptap/extension-text';
 import TextAlign from '@tiptap/extension-text-align';
+
 import { TextStyle } from '@tiptap/extension-text-style';
 import Underline from '@tiptap/extension-underline';
+import { Fragment, Node, Slice } from '@tiptap/pm/model';
 import { PluginKey } from '@tiptap/pm/state';
 import { Editor, EditorContent, ReactRenderer, useEditor } from '@tiptap/react';
 import Suggestion from '@tiptap/suggestion';
@@ -463,6 +464,62 @@ export function DescriptionEditor({
         if (readOnly) return;
         onChangeRef.current(e.getJSON() as Description);
       },
+      editorProps: {
+        transformPasted: (slice, view) => {
+          if (!view.editable) return slice;
+
+          const defaultColor = getComputedStyle(view.dom).color;
+          const { textStyle } = view.state.schema.marks;
+          if (!textStyle) return slice;
+
+          const normalizeDefault = rgbToHex(defaultColor);
+
+          // Recursively traverse the fragment and remove matching color marks
+          function transformFragment(fragment: Fragment): Fragment {
+            const nodes: Node[] = [];
+            fragment.forEach((node) => {
+              let newNode = node;
+              if (node.isText) {
+                const filteredMarks = node.marks.filter((mark) => {
+                  if (mark.type === textStyle) {
+                    const colorAttr = mark.attrs.color;
+                    if (colorAttr && rgbToHex(colorAttr) === normalizeDefault) {
+                      return false; // remove this mark
+                    }
+                  }
+                  return true;
+                });
+                if (filteredMarks.length !== node.marks.length) {
+                  newNode = view.state.schema.text(
+                    node.text ?? '',
+                    filteredMarks,
+                  );
+                }
+              } else if (node.isBlock) {
+                // Recurse into block content
+                const newContent = transformFragment(node.content);
+                if (newContent !== node.content) {
+                  newNode = node.type.create(
+                    node.attrs,
+                    newContent,
+                    node.marks,
+                  );
+                }
+              }
+              nodes.push(newNode);
+            });
+            return Fragment.fromArray(nodes);
+          }
+
+          const newContent = transformFragment(slice.content);
+          const newSlice = new Slice(
+            newContent,
+            slice.openStart,
+            slice.openEnd,
+          );
+          return newSlice;
+        },
+      },
     },
     [id],
   );
@@ -508,4 +565,25 @@ export function DescriptionEditor({
       )}
     </Box>
   );
+}
+
+/**
+ * Normalize a CSS color string to a 6‑digit hex (e.g. '#c9c9c9').
+ * Handles rgb/rgba and hex shorthand.
+ */
+function rgbToHex(color: string): string {
+  const trimmed = color.trim().toLowerCase();
+  // rgb/rgba
+  const rgbMatch = trimmed.match(/^rgba?\s*\((\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+  if (rgbMatch) {
+    const r = parseInt(rgbMatch[1], 10);
+    const g = parseInt(rgbMatch[2], 10);
+    const b = parseInt(rgbMatch[3], 10);
+    return `#${[r, g, b].map((c) => c.toString(16).padStart(2, '0')).join('')}`;
+  }
+  // hex shorthand
+  if (trimmed.startsWith('#') && trimmed.length === 4) {
+    return `#${trimmed[1]}${trimmed[1]}${trimmed[2]}${trimmed[2]}${trimmed[3]}${trimmed[3]}`;
+  }
+  return trimmed; // fallback (assumes full hex or named color)
 }

--- a/apps/postybirb-ui/src/components/shared/description-editor/description-editor.tsx
+++ b/apps/postybirb-ui/src/components/shared/description-editor/description-editor.tsx
@@ -472,31 +472,35 @@ export function DescriptionEditor({
           const { textStyle } = view.state.schema.marks;
           if (!textStyle) return slice;
 
-          const normalizeDefault = rgbToHex(defaultColor);
+          const defaultHex = cssColorToHex(defaultColor);
 
-          // Recursively traverse the fragment and remove matching color marks
-          function transformFragment(fragment: Fragment): Fragment {
+          const transformFragment = (fragment: Fragment): Fragment => {
             const nodes: Node[] = [];
             fragment.forEach((node) => {
               let newNode = node;
+
               if (node.isText) {
-                const filteredMarks = node.marks.filter((mark) => {
-                  if (mark.type === textStyle) {
-                    const colorAttr = mark.attrs.color;
-                    if (colorAttr && rgbToHex(colorAttr) === normalizeDefault) {
-                      return false; // remove this mark
-                    }
-                  }
-                  return true;
-                });
-                if (filteredMarks.length !== node.marks.length) {
-                  newNode = view.state.schema.text(
-                    node.text ?? '',
-                    filteredMarks,
-                  );
+                // Process marks: normalize color, drop default ones
+                const newMarks = node.marks
+                  .map((mark) => {
+                    if (mark.type !== textStyle) return mark;
+                    const { color } = mark.attrs;
+                    const hex = color ? cssColorToHex(color) : defaultHex;
+                    return hex === defaultHex
+                      ? null // drop default-colored mark
+                      : textStyle.create({ ...mark.attrs, color: hex });
+                  })
+                  .filter((e) => e !== null);
+
+                // Replace text node only if marks actually changed
+                const changed =
+                  newMarks.length !== node.marks.length ||
+                  newMarks.some((m, i) => m !== node.marks[i]);
+
+                if (changed) {
+                  newNode = view.state.schema.text(node.text ?? '', newMarks);
                 }
               } else if (node.isBlock) {
-                // Recurse into block content
                 const newContent = transformFragment(node.content);
                 if (newContent !== node.content) {
                   newNode = node.type.create(
@@ -506,18 +510,14 @@ export function DescriptionEditor({
                   );
                 }
               }
+
               nodes.push(newNode);
             });
             return Fragment.fromArray(nodes);
-          }
+          };
 
           const newContent = transformFragment(slice.content);
-          const newSlice = new Slice(
-            newContent,
-            slice.openStart,
-            slice.openEnd,
-          );
-          return newSlice;
+          return new Slice(newContent, slice.openStart, slice.openEnd);
         },
       },
     },
@@ -569,21 +569,22 @@ export function DescriptionEditor({
 
 /**
  * Normalize a CSS color string to a 6‑digit hex (e.g. '#c9c9c9').
- * Handles rgb/rgba and hex shorthand.
+ * Handles rgb/rgba/okhl/other
  */
-function rgbToHex(color: string): string {
-  const trimmed = color.trim().toLowerCase();
-  // rgb/rgba
-  const rgbMatch = trimmed.match(/^rgba?\s*\((\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
-  if (rgbMatch) {
-    const r = parseInt(rgbMatch[1], 10);
-    const g = parseInt(rgbMatch[2], 10);
-    const b = parseInt(rgbMatch[3], 10);
-    return `#${[r, g, b].map((c) => c.toString(16).padStart(2, '0')).join('')}`;
-  }
-  // hex shorthand
-  if (trimmed.startsWith('#') && trimmed.length === 4) {
-    return `#${trimmed[1]}${trimmed[1]}${trimmed[2]}${trimmed[2]}${trimmed[3]}${trimmed[3]}`;
-  }
-  return trimmed; // fallback (assumes full hex or named color)
+function cssColorToHex(color: string): string {
+  const el = document.createElement('div');
+  el.style.color = color;
+  el.style.display = 'none';
+  document.body.appendChild(el);
+  const computed = getComputedStyle(el).color;
+  document.body.removeChild(el);
+
+  // computed is like "rgb(r, g, b)" or "rgba(r, g, b, a)"
+  const rgbMatch = computed.match(/^rgba?\s*\((\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+  if (!rgbMatch) return '';
+
+  const r = parseInt(rgbMatch[1], 10);
+  const g = parseInt(rgbMatch[2], 10);
+  const b = parseInt(rgbMatch[3], 10);
+  return `#${[r, g, b].map((c) => c.toString(16).padStart(2, '0')).join('')}`;
 }


### PR DESCRIPTION
1) Standartizes color picker from being both in bubble menu and toolbar to be only in toolbar because the bubble menu one was half working solution (it was not possible to use the input/color selection, it was loosing focus before the select was happening. Fixing it was not really possible without tons of workarounds so i decided to simply remove it from bubble menu because its already in toolbar)
2) Makes the color selection itself appear without additional clicks, removing the "popover in popover" scenario that was present before. Removing it makes the UX more intuitive (some users have reported that they didn't even know they could use color picker in the old scenario)
3) Adds "Reset color" button to color picker

The most important fix: when copy-pasting text with color that matches editor color it pastes it as uncolored to prevent unexpected behavior (previously text that looked identical in editor would look different after being posted)

